### PR TITLE
separation of concerns

### DIFF
--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -58,4 +58,5 @@ library
   import:          lang
   exposed-modules: Test
                  , Proper.Plutus
+                 , Proper.Minimal
   hs-source-dirs:  src

--- a/src/Proper/Minimal.hs
+++ b/src/Proper/Minimal.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Proper.Minimal (
+  Proper (..),
+  Proposition,
+  Formula (..),
+) where
+
+import Data.Functor.Identity (Identity)
+import Data.Kind (Type)
+import Data.List (notElem)
+import Data.Map.Lazy qualified as M
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.String (fromString)
+import Hedgehog (
+  GenBase,
+  Group (..),
+  MonadGen,
+  PropertyT,
+  forAll,
+  property,
+  (===),
+ )
+import Hedgehog qualified
+import Hedgehog.Gen qualified as Gen
+import SAT.MiniSat (
+  Formula (..),
+  satisfiable,
+  solve_all,
+ )
+import Prelude (
+  Bool (..),
+  Bounded (..),
+  Enum,
+  Eq,
+  Maybe (..),
+  Ord,
+  Show (..),
+  String,
+  IO,
+  filter,
+  ($),
+  (<$>),
+  (==),
+ )
+
+--------------------------------------------------------------------------------
+-- Propositional logic is used to define two aspects of a model.
+-- The expected outcome of a test and the sets of properties which are valid in
+-- conjunction.
+--------------------------------------------------------------------------------
+
+type Proposition (a :: Type) = (Enum a, Eq a, Ord a, Bounded a, Show a)
+
+-- Proper is a type family over a Model and its Properties
+-- It encapsulates the model checking pattern shown in this diagram
+--
+-- Formula (Property model)        Set (Property model)
+--            \                    /       ^
+--             \                  /         \
+--              \ genP         = /           \ satisfies
+--               \              /      A      \
+--                \            /               \
+--                 v          /      genM       \
+--          Set (Property model) -------------> Model model
+--                 |                                    \
+--                 |                                     \
+--         expect  |                  B                   \ translate
+--                 |                                       \
+--                 v          =                 eval        v
+--               Result ------------- Result <----------- DeviceUnderTest
+--
+-- 'A' checks consistency between the model specification and its generator.
+-- 'B' (which can be written after 'A' is complete) tests the compiled script.
+
+class Proper model where
+  -- a model encodes the data relevant to a specification
+  data Model model :: Type
+
+  -- properties are things that may be true of a model
+  data Property model :: Type
+
+  -- the device under test is the object we are verifying the properties of
+  data DeviceUnderTest model :: Type
+
+  -- check whether a property is satisfied
+  satisfiesProperty :: Model model -> Property model -> Bool
+
+  -- generates a model that satisfies a set of properties
+  genModel :: MonadGen m => Set (Property model) -> m (Model model)
+
+  -- propositional logic over model properties defines sets of properties valid in conjunction
+  logic :: Formula (Property model)
+  logic = Yes
+
+  -- given a set of properties we expect a script to pass or fail
+  expect :: Formula (Property model)
+  expect = Yes
+
+  satisfiesFormula :: Proposition (Property model) => Formula (Property model) -> Set (Property model) -> Bool
+  satisfiesFormula f s = satisfiable $ f :&&: All (Var <$> set) :&&: None (Var <$> unset)
+    where
+      set :: [Property model]
+      set = Set.toList s
+      unset :: [Property model]
+      unset = filter (`notElem` s) ([minBound .. maxBound] :: [Property model])
+
+  enumerateScenariosWhere :: Proposition (Property model) => Formula (Property model) -> [Set (Property model)]
+  enumerateScenariosWhere condition = enumerateSolutions $ logic :&&: condition :&&: allPresentInFormula
+    where
+      allPresentInFormula :: Formula (Property model)
+      allPresentInFormula = All (mention <$> ([minBound .. maxBound] :: [Property model]))
+      mention :: Property model -> Formula (Property model)
+      mention p = Var p :||: Not (Var p)
+      fromSolution :: Proposition p => M.Map p Bool -> Set p
+      fromSolution m = Set.fromList $ filter isInSet [minBound .. maxBound]
+        where
+          isInSet k = Just True == M.lookup k m
+      enumerateSolutions :: Proposition p => Formula p -> [Set p]
+      enumerateSolutions f = fromSolution <$> solve_all f
+
+  genGivenFormula :: (Proposition (Property model), MonadGen m, GenBase m ~ Identity) => Formula (Property model) -> m (Set (Property model))
+  genGivenFormula f =
+    let g = Set.fromList <$> Gen.subsequence [minBound .. maxBound]
+     in Gen.filter (satisfiesFormula f) g
+
+  -- compute the properties of a model
+  properties ::
+    Proposition (Property model) =>
+    Model model ->
+    Set (Property model)
+  properties x = Set.fromList $ filter (satisfiesProperty x) [minBound .. maxBound]
+
+  -- generates a set of properties (gen)
+  genProperties ::
+    (Proposition (Property model), MonadGen m, GenBase m ~ Identity) =>
+    model ->
+    m (Set (Property model))
+  genProperties _ = genGivenFormula logic
+
+  buildDeviceUnderTest :: Model model -> Maybe (DeviceUnderTest model)
+  buildDeviceUnderTest _ = Nothing
+
+  -- HedgeHog properties and property groups
+
+  modelTestGivenProperties ::
+    Proposition (Property model) =>
+    Show (Model model) =>
+    Set (Property model) ->
+    Hedgehog.Property
+  modelTestGivenProperties properties' =
+    property $ do
+      model <- forAll $ genModel properties'
+      properties model === properties'
+
+  deviceTestGivenProperties ::
+    Proposition (Property model) =>
+    Show (Model model) =>
+    (Model model -> PropertyT IO ()) ->
+    Set (Property model) ->
+    Hedgehog.Property
+  deviceTestGivenProperties runDeviceTest properties' =
+    property $ do
+      model <- forAll $ genModel properties'
+      runDeviceTest model
+
+  testEnumeratedScenarios ::
+    Proposition (Property model) =>
+    Show (Model model) =>
+    Show model =>
+    model ->
+    String ->
+    (Set (Property model) -> Hedgehog.Property) ->
+    Formula (Property model) ->
+    Group
+  testEnumeratedScenarios _ groupname test cond =
+    Group (fromString groupname) $
+      [ (fromString $ show $ Set.toList p, test p)
+      | p <- enumerateScenariosWhere cond
+      ]
+

--- a/src/Proper/Minimal.hs
+++ b/src/Proper/Minimal.hs
@@ -62,11 +62,11 @@ type Proposition (a :: Type) = (Enum a, Eq a, Ord a, Bounded a, Show a)
 --              \ genP         = /           \ satisfies
 --               \              /      A      \
 --                \            /               \
---                 v          /      genM       \
+--                 v          /      genModel   \
 --          Set (Property model) -------------> Model model
 --                 |                                    \
 --                 |                                     \
---         expect  |                  B                   \ translate
+--         expect  |                  B                   \ buildDevice
 --                 |                                       \
 --                 v          =                 eval        v
 --               Result ------------- Result <----------- Device
@@ -157,13 +157,13 @@ class Proper model where
   deviceTestGivenProperties ::
     Proposition (Property model) =>
     Show (Model model) =>
-    (Device model -> PropertyT IO ()) ->
+    (Bool -> Device model -> PropertyT IO ()) ->
     Set (Property model) ->
     Hedgehog.Property
   deviceTestGivenProperties runDeviceTest properties' =
     property $ do
       model <- forAll $ genModel properties'
-      runDeviceTest $ buildDevice model
+      runDeviceTest (satisfiesFormula expect properties') $ buildDevice model
 
   testEnumeratedScenarios ::
     Proposition (Property model) =>


### PR DESCRIPTION
The goal of this PR is to separate the property generation logic
from the test runner. The plan is to add plugable back-ends for
testing in different model contexts e.g. Plutarch script, Transaction,
ScriptContext (Validator,Minting,...).