### PR TITLE
Fraser/abstraction

### DIFF
--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -41,6 +41,7 @@ common lang
                     , containers
                     , hedgehog
                     , free
+                    , lens
                     , minisat-solver
                     , mtl
                     , plutarch
@@ -67,6 +68,7 @@ library
                  , Apropos.HasLogicalModel
                  , Apropos.HasParameterisedGenerator
                  , Apropos.HasPermutationGenerator
+                 , Apropos.HasPermutationGenerator.Abstraction
                  , Apropos.HasPermutationGenerator.Contract
                  , Apropos.HasPermutationGenerator.PermutationEdge
                  , Apropos.Gen

--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -40,6 +40,7 @@ common lang
   build-depends:      base ^>=4.14
                     , containers
                     , hedgehog
+                    , free
                     , minisat-solver
                     , mtl
                     , plutarch

--- a/examples/Spec/IntPair.hs
+++ b/examples/Spec/IntPair.hs
@@ -38,36 +38,23 @@ instance HasLogicalModel IntPairProp (Int, Int) where
 
 instance HasPermutationGenerator IntPairProp (Int, Int) where
   generators =
-    --TODO liftEdges could be prettier - we could use lenses to
-    --                                 -            get and set a substructure in the model
-    --                                 -            Maybe extract a subproperty from a property
-    --
-    --                                 - we could derive the prefix string from the property constructor
-    --
-    --                                 - then we would have a 4 argument function instead of a 6 argument function
-    let l =
-          liftEdges
-            L
-            fst
-            (\f (_, r') -> (f, r'))
-            ( \p -> case p of
-                (L q) -> Just q
-                _ -> Nothing
-            )
-            "L"
-            generators
-        r =
-          liftEdges
-            R
-            snd
-            (\f (l', _) -> (l', f))
-            ( \p -> case p of
-                (R q) -> Just q
-                _ -> Nothing
-            )
-            "R"
-            generators
-     in join [l, r]
+    let l = ModelAbstraction { abstractionName = "L"
+                             , projectProperty =  \p -> case p of
+                                                          (L q) -> Just q
+                                                          _ -> Nothing
+                             , injectProperty = L
+                             , projectSubmodel = fst
+                             , injectSubmodel = \f (_, r') -> (f, r')
+                             }
+        r = ModelAbstraction { abstractionName = "R"
+                             , projectProperty =  \p -> case p of
+                                                          (R q) -> Just q
+                                                          _ -> Nothing
+                             , injectProperty = R
+                             , projectSubmodel = snd
+                             , injectSubmodel = \f (l', _) -> (l', f)
+                             }
+     in join [l <$$> generators, r <$$> generators]
 
 instance HasParameterisedGenerator IntPairProp (Int, Int) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/IntPair.hs
+++ b/examples/Spec/IntPair.hs
@@ -21,6 +21,7 @@ import Plutarch.Prelude
 import Spec.IntPermutationGen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
+import Control.Lens.Tuple(_1,_2)
 
 data IntPairProp
   = L IntProp
@@ -38,23 +39,15 @@ instance HasLogicalModel IntPairProp (Int, Int) where
 
 instance HasPermutationGenerator IntPairProp (Int, Int) where
   generators =
-    let l = ModelAbstraction { abstractionName = "L"
-                             , projectProperty =  \p -> case p of
-                                                          (L q) -> Just q
-                                                          _ -> Nothing
-                             , injectProperty = L
-                             , projectSubmodel = fst
-                             , injectSubmodel = \f (_, r') -> (f, r')
-                             }
-        r = ModelAbstraction { abstractionName = "R"
-                             , projectProperty =  \p -> case p of
-                                                          (R q) -> Just q
-                                                          _ -> Nothing
-                             , injectProperty = R
-                             , projectSubmodel = snd
-                             , injectSubmodel = \f (l', _) -> (l', f)
-                             }
-     in join [l <$$> generators, r <$$> generators]
+    let l = Abstraction { abstractionName = "L"
+                        , propertyAbstraction = abstractsProperties L
+                        , modelAbstraction = _1
+                        }
+        r = Abstraction { abstractionName = "R"
+                        , propertyAbstraction = abstractsProperties R
+                        , modelAbstraction = _2
+                        }
+     in join [abstract l <$> generators, abstract r <$> generators]
 
 instance HasParameterisedGenerator IntPairProp (Int, Int) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/TicTacToe/Move.hs
+++ b/examples/Spec/TicTacToe/Move.hs
@@ -17,6 +17,8 @@ import Spec.TicTacToe.Location
 import Spec.TicTacToe.Player
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
+import Control.Lens.Tuple(_1,_2)
+
 
 data MoveProperty
   = MoveLocation LocationProperty
@@ -34,23 +36,15 @@ instance HasLogicalModel MoveProperty (Int, Int) where
 
 instance HasPermutationGenerator MoveProperty (Int, Int) where
   generators =
-    let l = ModelAbstraction { abstractionName = "MovePlayer"
-                             , projectProperty =  \p -> case p of
-                                                          (MovePlayer q) -> Just q
-                                                          _ -> Nothing
-                             , injectProperty = MovePlayer
-                             , projectSubmodel = fst
-                             , injectSubmodel = \f (_, r') -> (f, r')
+    let l = Abstraction { abstractionName = "MovePlayer"
+                        , propertyAbstraction = abstractsProperties MovePlayer
+                        , modelAbstraction = _1
+                        }
+        r = Abstraction { abstractionName = "MoveLocation"
+                        , propertyAbstraction = abstractsProperties MoveLocation
+                        , modelAbstraction = _2
                              }
-        r = ModelAbstraction { abstractionName = "MoveLocation"
-                             , projectProperty =  \p -> case p of
-                                                          (MoveLocation q) -> Just q
-                                                          _ -> Nothing
-                             , injectProperty = MoveLocation
-                             , projectSubmodel = snd
-                             , injectSubmodel = \f (l', _) -> (l', f)
-                             }
-     in join [l <$$> generators, r <$$> generators]
+     in join [abstract l <$> generators, abstract r <$> generators]
 
 instance HasParameterisedGenerator MoveProperty (Int, Int) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/TicTacToe/Move.hs
+++ b/examples/Spec/TicTacToe/Move.hs
@@ -34,29 +34,23 @@ instance HasLogicalModel MoveProperty (Int, Int) where
 
 instance HasPermutationGenerator MoveProperty (Int, Int) where
   generators =
-    let l =
-          liftEdges
-            MovePlayer
-            fst
-            (\f (_, r') -> (f, r'))
-            ( \p -> case p of
-                (MovePlayer q) -> Just q
-                _ -> Nothing
-            )
-            "MovePlayer "
-            generators
-        r =
-          liftEdges
-            MoveLocation
-            snd
-            (\f (l', _) -> (l', f))
-            ( \p -> case p of
-                (MoveLocation q) -> Just q
-                _ -> Nothing
-            )
-            "MoveLocation "
-            generators
-     in join [l, r]
+    let l = ModelAbstraction { abstractionName = "MovePlayer"
+                             , projectProperty =  \p -> case p of
+                                                          (MovePlayer q) -> Just q
+                                                          _ -> Nothing
+                             , injectProperty = MovePlayer
+                             , projectSubmodel = fst
+                             , injectSubmodel = \f (_, r') -> (f, r')
+                             }
+        r = ModelAbstraction { abstractionName = "MoveLocation"
+                             , projectProperty =  \p -> case p of
+                                                          (MoveLocation q) -> Just q
+                                                          _ -> Nothing
+                             , injectProperty = MoveLocation
+                             , projectSubmodel = snd
+                             , injectSubmodel = \f (l', _) -> (l', f)
+                             }
+     in join [l <$$> generators, r <$$> generators]
 
 instance HasParameterisedGenerator MoveProperty (Int, Int) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
+++ b/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
@@ -51,29 +51,31 @@ instance HasLogicalModel PlayerLocationSequencePairProperty ([Int], [Int]) where
 
 instance HasPermutationGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   generators =
-    let l =
-          liftEdges
-            PlayerLocationSequencePairPlayer
-            fst
-            (\f moves -> (f, snd moves))
-            ( \p -> case p of
-                (PlayerLocationSequencePairPlayer q) -> Just q
-                _ -> Nothing
-            )
-            ""
-            generators
-        r =
-          liftEdges
-            PlayerLocationSequencePairLocation
-            snd
-            (\f moves -> (fst moves, f))
-            ( \p -> case p of
-                (PlayerLocationSequencePairLocation q) -> Just q
-                _ -> Nothing
-            )
-            ""
-            generators
-     in [composeEdges l' r' | l' <- l, r' <- r]
+    let l = ModelAbstraction { abstractionName = ""
+                             , projectProperty =  \p ->
+                                 case p of
+                                   (PlayerLocationSequencePairPlayer q) -> Just q
+                                   _ -> Nothing
+                             , injectProperty = PlayerLocationSequencePairPlayer
+                             , projectSubmodel = fst
+                             , injectSubmodel = \f moves -> (f, snd moves)
+
+                             }
+        r = ModelAbstraction { abstractionName = ""
+                             , projectProperty =  \p ->
+                                 case p of
+                                   (PlayerLocationSequencePairLocation q) -> Just q
+                                   _ -> Nothing
+                             , injectProperty = PlayerLocationSequencePairLocation
+                             , projectSubmodel = snd
+                             , injectSubmodel = \f moves -> (fst moves, f)
+                             }
+     in (l <$$> generators) <*>> (r <$$> generators)
+
+--   how can we make this look like applicative where we have
+--     PairProp IntProp IntProp
+--   in pairPropAbstraction <$$> generators <**> generators
+--   ?
 
 instance HasParameterisedGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
+++ b/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
@@ -17,6 +17,8 @@ import Spec.TicTacToe.LocationSequence
 import Spec.TicTacToe.PlayerSequence
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
+import Control.Lens.Tuple(_1,_2)
+
 
 data PlayerLocationSequencePairProperty
   = PlayerLocationSequencePairLocation LocationSequenceProperty
@@ -51,31 +53,15 @@ instance HasLogicalModel PlayerLocationSequencePairProperty ([Int], [Int]) where
 
 instance HasPermutationGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   generators =
-    let l = ModelAbstraction { abstractionName = ""
-                             , projectProperty =  \p ->
-                                 case p of
-                                   (PlayerLocationSequencePairPlayer q) -> Just q
-                                   _ -> Nothing
-                             , injectProperty = PlayerLocationSequencePairPlayer
-                             , projectSubmodel = fst
-                             , injectSubmodel = \f moves -> (f, snd moves)
-
-                             }
-        r = ModelAbstraction { abstractionName = ""
-                             , projectProperty =  \p ->
-                                 case p of
-                                   (PlayerLocationSequencePairLocation q) -> Just q
-                                   _ -> Nothing
-                             , injectProperty = PlayerLocationSequencePairLocation
-                             , projectSubmodel = snd
-                             , injectSubmodel = \f moves -> (fst moves, f)
-                             }
-     in (l <$$> generators) <*>> (r <$$> generators)
-
---   how can we make this look like applicative where we have
---     PairProp IntProp IntProp
---   in pairPropAbstraction <$$> generators <**> generators
---   ?
+    let l = Abstraction { abstractionName = ""
+                        , propertyAbstraction = abstractsProperties PlayerLocationSequencePairPlayer
+                        , modelAbstraction = _1
+                        }
+        r = Abstraction { abstractionName = ""
+                        , propertyAbstraction = abstractsProperties PlayerLocationSequencePairLocation
+                        , modelAbstraction = _2
+                        }
+     in (abstract l <$> generators) |:-> (abstract r <$> generators)
 
 instance HasParameterisedGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   parameterisedGenerator = buildGen baseGen

--- a/src/Apropos/HasPermutationGenerator.hs
+++ b/src/Apropos/HasPermutationGenerator.hs
@@ -1,8 +1,9 @@
 module Apropos.HasPermutationGenerator (
   HasPermutationGenerator(..),
   PermutationEdge(..),
-  liftEdges,
-  composeEdges,
+  ModelAbstraction(..),
+  (<$$>),
+  (<*>>),
   ) where
 import Apropos.Gen
 import Apropos.HasLogicalModel

--- a/src/Apropos/HasPermutationGenerator.hs
+++ b/src/Apropos/HasPermutationGenerator.hs
@@ -1,15 +1,17 @@
 module Apropos.HasPermutationGenerator (
   HasPermutationGenerator(..),
   PermutationEdge(..),
-  ModelAbstraction(..),
-  (<$$>),
-  (<*>>),
+  Abstraction(..),
+  abstract,
+  abstractsProperties,
+  (|:->),
   ) where
 import Apropos.Gen
 import Apropos.HasLogicalModel
 import Apropos.LogicalModel
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.HasPermutationGenerator.PermutationEdge
+import Apropos.HasPermutationGenerator.Abstraction
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Hedgehog (Gen,PropertyT,MonadTest,Group(..),forAll,failure,footnote,property,label)

--- a/src/Apropos/HasPermutationGenerator/Abstraction.hs
+++ b/src/Apropos/HasPermutationGenerator/Abstraction.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE RankNTypes #-}
+module Apropos.HasPermutationGenerator.Abstraction (
+  Abstraction(..),
+  abstract,
+  abstractsProperties,
+  (|:->),
+  ) where
+import Apropos.LogicalModel.Enumerable
+import Apropos.LogicalModel.Formula
+import Apropos.HasPermutationGenerator.Contract
+import Apropos.HasPermutationGenerator.PermutationEdge
+import Apropos.Gen
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Either (rights)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Reader (ask) --TODO refactor gen monad abstraction
+import Control.Lens
+
+data Abstraction ap am bp bm =
+  Abstraction {
+    abstractionName :: String
+  , propertyAbstraction :: Prism' bp ap
+  , modelAbstraction :: Lens' bm am
+  }
+
+abstract :: Enumerable ap
+             => Enumerable bp
+             => Abstraction ap am bp bm -> PermutationEdge ap am -> PermutationEdge bp bm
+abstract abstraction edge =
+  PermutationEdge {
+    name = (abstractionName abstraction) <> name edge
+  , match = ((propertyAbstraction abstraction) #) <$> match edge
+  , contract = abstractContract (abstractionName abstraction)
+                                (propertyAbstraction abstraction) $ contract edge
+  , permuteGen = do
+        m <- ask
+        let n = m ^. (modelAbstraction abstraction)
+        nn <- lift $ runGenPA (permuteGen edge) n
+        pure $ (modelAbstraction abstraction) .~ nn $ m
+  }
+
+abstractsProperties :: Enumerable a => Enumerable b => (a -> b) -> Prism' b a
+abstractsProperties injection = prism' injection (computeProjection injection)
+  where
+    computeProjection :: Enumerable a => Enumerable b => (a -> b) -> (b -> Maybe a)
+    computeProjection f = g
+      where g b = lookup b (zip (f <$> enumerated) enumerated)
+
+abstractContract :: (Ord a, Ord b) => String -> Prism' b a -> Contract a () -> Contract b ()
+abstractContract prefix a c = do
+  i <- readContractOutput
+  n <- readContractEdgeName
+  let subm = projectProperties a i
+      subx = maskProperties a i
+      res = runContract c (prefix <> n) subm
+  case res of
+    Left err -> contractError err
+    Right Nothing -> terminal
+    Right (Just upd) ->
+      output (subx `Set.union` injectProperties a upd)
+  where
+    injectProperties :: Ord b => Prism' b a -> Set a -> Set b
+    injectProperties pa = Set.map (pa #)
+    projectProperties :: Ord a => Prism' b a -> Set b -> Set a
+    projectProperties pa s = Set.fromList $ rights ((matching pa) <$> Set.toList s)
+    maskProperties :: Prism' b a -> Set b -> Set b
+    maskProperties pa = Set.filter (isn't pa)
+
+(|:->) :: [PermutationEdge p m] -> [PermutationEdge p m] -> [PermutationEdge p m]
+(|:->) as bs = [composeEdges a b | a <- as, b <- bs]
+
+composeEdges :: PermutationEdge p m -> PermutationEdge p m -> PermutationEdge p m
+composeEdges a b =
+  PermutationEdge
+    { name = name a <> name b
+    , match = match a :&&: match b
+    , contract = contract a >> contract b
+    , permuteGen = do
+        m <- ask
+        ma <- lift $ runGenPA (permuteGen a) m
+        lift $ runGenPA (permuteGen b) ma
+    }
+
+

--- a/src/Apropos/HasPermutationGenerator/Contract.hs
+++ b/src/Apropos/HasPermutationGenerator/Contract.hs
@@ -1,10 +1,12 @@
 module Apropos.HasPermutationGenerator.Contract (
   Contract,
+  PropertyProjection(..),
+  projection,
   runContract,
   readContractInput,
   readContractEdgeName,
   readContractOutput,
-  setContractOutput,
+  writeContractOutput,
   branches,
   branchIf,
   has,
@@ -24,10 +26,11 @@ module Apropos.HasPermutationGenerator.Contract (
 ) where
 
 import Control.Monad.Reader (ReaderT, ask, runReaderT)
-import Control.Monad.State (StateT, get, modify, put, runStateT)
+import Control.Monad.State (StateT, get, put, runStateT)
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Maybe (MaybeT, runMaybeT)
-import Data.Maybe (catMaybes)
+import Control.Monad.Free
+import Data.Maybe (catMaybes,isNothing)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.String (fromString)
@@ -40,33 +43,97 @@ import Text.PrettyPrint (
  )
 import Text.Show.Pretty (ppDoc)
 
-type Contract p a = MaybeT (ReaderT (String, Set p) (StateT (Set p) (Either String))) a
+data FreeContract p next =
+    ReadContractInput (Set p -> next)
+  | ReadContractEdgeName (String -> next)
+  | ReadContractOutput (Set p -> next)
+  | WriteContractOutput (Set p) next
+  | ContractError String next
+  | Terminal next
 
-runContract :: Contract p () -> String -> Set p -> Either String (Maybe (Set p))
-runContract c nm s = do
-  (b, s') <- runStateT (runReaderT (runMaybeT c) (nm, s)) s
-  case b of
-    Just () -> pure $ Just s'
-    Nothing -> pure Nothing
+instance Functor (FreeContract p) where
+  fmap f (ReadContractInput r) = ReadContractInput (f . r)
+  fmap f (ReadContractEdgeName r) = ReadContractEdgeName (f . r)
+  fmap f (ReadContractOutput r) = ReadContractOutput (f . r)
+  fmap f (WriteContractOutput r next) = WriteContractOutput r (f next)
+  fmap f (ContractError err next) = ContractError err (f next)
+  fmap f (Terminal next) = Terminal (f next)
 
-runContractInternal :: Contract p () -> String -> Set p -> Set p -> Either String (Maybe (Set p))
-runContractInternal c nm s i = do
-  (b, s') <- runStateT (runReaderT (runMaybeT c) (nm, s)) i
-  case b of
-    Just () -> pure $ Just s'
-    Nothing -> pure Nothing
+data PropertyProjection b a = PropertyProjection {
+    projectionName :: String
+  , projectionFunction :: b -> Maybe a
+  , injectionFunction :: a -> b
+  }
+
+projection :: Ord a => Ord b => PropertyProjection b a -> Contract a () -> Contract b ()
+projection p c = do
+  i <- readContractOutput
+  n <- readContractEdgeName
+  let subm = extractSubmodel (projectionFunction p) i
+      subx = exciseSubmodel (projectionFunction p) i
+      res = runContract c ((projectionName p) <> n) subm
+  case res of
+    Left err -> contractError err
+    Right Nothing -> terminal
+    Right (Just upd) ->
+      output (subx `Set.union` (Set.map (injectionFunction p) upd))
+  where
+    extractSubmodel :: Ord p => (q -> Maybe p) -> Set q -> Set p
+    extractSubmodel f q = Set.fromList $ catMaybes (f <$> Set.toList q)
+    exciseSubmodel :: (q -> Maybe p) -> Set q -> Set q
+    exciseSubmodel f q = Set.filter (isNothing . f) q
+
+type Contract p = Free (FreeContract p)
 
 readContractInput :: Contract p (Set p)
-readContractInput = snd <$> lift ask
+readContractInput = liftF (ReadContractInput id)
 
 readContractEdgeName :: Contract p String
-readContractEdgeName = fst <$> lift ask
+readContractEdgeName = liftF (ReadContractEdgeName id)
 
 readContractOutput :: Contract p (Set p)
-readContractOutput = lift $ lift get
+readContractOutput = liftF (ReadContractOutput id)
 
-setContractOutput :: Set p -> Contract p ()
-setContractOutput = lift . lift . put
+writeContractOutput :: Set p -> Contract p ()
+writeContractOutput s = liftF (WriteContractOutput s ())
+
+contractError :: String -> Contract p ()
+contractError s = liftF (ContractError s ())
+
+terminal :: Contract p ()
+terminal = liftF (Terminal ())
+
+type ContractRun p a = MaybeT (ReaderT (String, Set p) (StateT (Set p) (Either String))) a
+
+interpret :: Contract p () -> ContractRun p ()
+interpret (Free (ReadContractInput next))     = (snd <$> lift ask) >>= interpret . next
+interpret (Free (ReadContractEdgeName next))  = (fst <$> lift ask) >>= interpret . next
+interpret (Free (ReadContractOutput next))    = (lift $ lift get)  >>= interpret . next
+interpret (Free (WriteContractOutput s next)) = (lift $ lift $ put s) >> interpret next
+interpret (Free (ContractError err next))     = (lift $ lift $ lift $ Left err) >> interpret next
+interpret (Free (Terminal next))              = fail "terminal" >> interpret next
+interpret (Pure a)                            = pure a
+
+runContract :: Contract p () -> String -> Set p -> Either String (Maybe (Set p))
+runContract = runContract' . interpret
+  where
+    runContract' :: ContractRun p () -> String -> Set p -> Either String (Maybe (Set p))
+    runContract' c nm s = do
+      (b, s') <- runStateT (runReaderT (runMaybeT c) (nm, s)) s
+      case b of
+        Just () -> pure $ Just s'
+        Nothing -> pure Nothing
+
+runContractInternal :: Contract p () -> String -> Set p -> Set p -> Contract p (Maybe (Set p))
+runContractInternal = runContractInternal' . interpret
+  where
+    runContractInternal' :: ContractRun p () -> String -> Set p -> Set p -> Contract p (Maybe (Set p))
+    runContractInternal' c nm s i = do
+      case runStateT (runReaderT (runMaybeT c) (nm, s)) i of
+        Left err -> contractError err >> pure Nothing
+        Right (b, s') -> case b of
+                           Just () -> pure $ Just s'
+                           Nothing -> pure Nothing
 
 --e.g. has ThisThing >> add ThatThing
 has :: Eq p => p -> Contract p ()
@@ -74,7 +141,7 @@ has p = do
   s <- readContractInput
   if p `elem` s
     then pure ()
-    else fail "Nothing"
+    else terminal
 
 --e.g. hasAll [ThisThing,ThatThing] >> add TheOtherThing
 hasAll :: Eq p => [p] -> Contract p ()
@@ -85,7 +152,7 @@ hasn't :: Eq p => p -> Contract p ()
 hasn't p = do
   s <- readContractInput
   if p `elem` s
-    then fail "Nothing"
+    then terminal
     else pure ()
 
 --e.g. hasNone [ThisThing,ThatThing] >> add TheOtherThing
@@ -93,10 +160,10 @@ hasNone :: Eq p => [p] -> Contract p ()
 hasNone = mapM_ hasn't
 
 add :: Ord p => p -> Contract p ()
-add p = lift $ lift $ modify (Set.insert p)
+add p = readContractOutput >>= writeContractOutput . Set.insert p
 
 remove :: Ord p => p -> Contract p ()
-remove p = lift $ lift $ modify (Set.delete p)
+remove p = readContractOutput >>= writeContractOutput . Set.delete p
 
 addAll :: Ord p => [p] -> Contract p ()
 addAll = mapM_ add
@@ -105,10 +172,10 @@ removeAll :: Ord p => [p] -> Contract p ()
 removeAll = mapM_ remove
 
 clear :: Contract p ()
-clear = lift $ lift $ put Set.empty
+clear = writeContractOutput Set.empty
 
 output :: Set p -> Contract p ()
-output = lift . lift . put
+output = writeContractOutput
 
 addIf :: (Ord p, Show p) => p -> p -> Contract p ()
 addIf p q = branches [has p >> add q, hasn't p]
@@ -130,19 +197,14 @@ branches cs = do
   i <- readContractInput
   e <- readContractEdgeName
   o <- readContractOutput
-  rs <- mapM (\c -> lift $ lift $ lift $ runContractInternal c e i o) cs
+  rs <- mapM (\c -> runContractInternal c e i o) cs
   case catMaybes rs of
-    [] -> fail "Nothing"
-    [ao] -> setContractOutput ao >> pure ()
+    [] -> terminal
+    [ao] -> writeContractOutput ao
     (ao : rest) ->
       if all (== ao) rest
-        then setContractOutput ao >> pure ()
-        else
-          lift $
-            lift $
-              lift $
-                Left $
-                  renderStyle ourStyle $
+        then writeContractOutput ao
+        else contractError $ renderStyle ourStyle $
                     (fromString $ "PermutationEdge " <> e <> " has non-deterministic type")
                       $+$ hang "error:" 4 "branches succeeded with different results in each branch."
                       $+$ hang "results:" 4 (ppDoc (ao : rest))

--- a/src/Apropos/HasPermutationGenerator/PermutationEdge.hs
+++ b/src/Apropos/HasPermutationGenerator/PermutationEdge.hs
@@ -2,15 +2,11 @@
 
 module Apropos.HasPermutationGenerator.PermutationEdge (
   PermutationEdge (..),
-  (<$$>),
-  (<*>>),
 ) where
 
 import Apropos.Gen
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.LogicalModel.Formula
-import Control.Monad.Trans (lift)
-import Control.Monad.Trans.Reader (ask)
 
 data PermutationEdge p m = PermutationEdge
   { name :: String
@@ -18,45 +14,6 @@ data PermutationEdge p m = PermutationEdge
   , contract :: Contract p ()
   , permuteGen :: PAGen m m
   }
-
-(<*>>) :: [PermutationEdge p m] -> [PermutationEdge p m] -> [PermutationEdge p m]
-(<*>>) as bs = [composeEdges a b | a <- as, b <- bs]
-
-composeEdges :: PermutationEdge p m -> PermutationEdge p m -> PermutationEdge p m
-composeEdges a b =
-  PermutationEdge
-    { name = name a <> name b
-    , match = match a :&&: match b
-    , contract = contract a >> contract b
-    , permuteGen = do
-        m <- ask
-        ma <- lift $ runGenPA (permuteGen a) m
-        lift $ runGenPA (permuteGen b) ma
-    }
-
-(<$$>) ::
-  (Ord p, Ord q) =>
-  ModelAbstraction q m p n ->
-  [PermutationEdge p n] ->
-  [PermutationEdge q m]
-(<$$>) abstraction edges = liftEdge abstraction <$> edges
-
-liftEdge ::
-  (Ord p, Ord q) =>
-  ModelAbstraction q m p n ->
-  PermutationEdge p n ->
-  PermutationEdge q m
-liftEdge abstraction edge =
-  PermutationEdge
-    { name = ((abstractionName abstraction) <> name edge)
-    , match = (injectProperty abstraction) <$> match edge
-    , contract = propertyAbstraction abstraction $ contract edge
-    , permuteGen = do
-        m <- ask
-        let n = (projectSubmodel abstraction) m
-        nn <- lift $ runGenPA (permuteGen edge) n
-        pure $ (injectSubmodel abstraction) nn m
-    }
 
 instance Eq (PermutationEdge p m) where
   (==) a b = name a == name b

--- a/src/Apropos/LogicalModel/Enumerable.hs
+++ b/src/Apropos/LogicalModel/Enumerable.hs
@@ -2,5 +2,5 @@ module Apropos.LogicalModel.Enumerable (
   Enumerable (..),
 ) where
 
-class Enumerable p where
+class (Eq p, Ord p) => Enumerable p where
   enumerated :: [p]

--- a/src/Apropos/LogicalModel/Formula.hs
+++ b/src/Apropos/LogicalModel/Formula.hs
@@ -34,23 +34,6 @@ data Formula v
   | AtMostOne [Formula v]
   deriving stock (Generic, Functor)
 
-instance Applicative Formula where
-  pure a = Var a
-  (<*>) (Var aTob) (Var a) = Var (aTob a)
-  (<*>) (Var aTob) a = aTob <$> a
-  (<*>) Yes Yes = Yes
-  (<*>) (aTobL :&&:  aTobR) a = (aTobL <*> a) :&&:  (aTobR <*> a)
-  (<*>) (aTobL :||:  aTobR) a = (aTobL <*> a) :||:  (aTobR <*> a)
-  (<*>) (aTobL :++:  aTobR) a = (aTobL <*> a) :++:  (aTobR <*> a)
-  (<*>) (aTobL :->:  aTobR) a = (aTobL <*> a) :->:  (aTobR <*> a)
-  (<*>) (aTobL :<->: aTobR) a = (aTobL <*> a) :<->: (aTobR <*> a)
-  (<*>) (All        aTobs) a = All         [ aTob <*> a | aTob <- aTobs ]
-  (<*>) (Some       aTobs) a = Some        [ aTob <*> a | aTob <- aTobs ]
-  (<*>) (None       aTobs) a = None        [ aTob <*> a | aTob <- aTobs ]
-  (<*>) (ExactlyOne aTobs) a = ExactlyOne  [ aTob <*> a | aTob <- aTobs ]
-  (<*>) (AtMostOne  aTobs) a = AtMostOne   [ aTob <*> a | aTob <- aTobs ]
-  (<*>) _ _ = No
-
 translateToSAT :: Formula v -> S.Formula v
 translateToSAT (Var v) = S.Var v
 translateToSAT Yes = S.Yes


### PR DESCRIPTION
Refactor generator abstraction to use a Lens/Prism pair.

```Haskell
    let l = Abstraction { abstractionName = "L"
                        , propertyAbstraction = abstractsProperties L
                        , modelAbstraction = _1
                        }
        r = Abstraction { abstractionName = "R"
                        , propertyAbstraction = abstractsProperties R
                        , modelAbstraction = _2
                        }
     in join [abstract l <$> generators, abstract r <$> generators]
```

Refactor Contract to a Free Monad. No API change but this decouples us from the underlying Monad stack and will allow us to swap it out if need be. Thinking of doing a similar thing for `Apropos.Gen`.