### PR TITLE
Fraser/generator refactor

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,4 +11,5 @@
 - Create road plan for `apropos-plutus` standard library models
   - having a shared library of specifications could make the library more usable
   - this shared library might be best developed by encouraging upstreaming from library users
-
+- Collect space size statistics from generators. Generate 1000 values or so and filter identical values - this could be an interesting statistic. If we have generators that only produce a small number of values for some parameterisation we could reduce the number of tests for that space, flag this as a notable statistic that may indicate a problem, perhaps other use cases or statistics could be found.
+- Attach weights to propositions such that we can modulate the number of tests in each property based on these weights. We could allow user specified importance weightings and combine these with weights derived from distribution introspection as described above.This will allow the user to express importance and stop us wasting cycles on generators that have exhausted their space.

--- a/examples/Spec/Int.hs
+++ b/examples/Spec/Int.hs
@@ -7,10 +7,8 @@ import Apropos.HasParameterisedGenerator
 import Apropos.LogicalModel
 import Apropos.Pure
 import Apropos.Script
+import Apropos.Gen
 import Data.Proxy (Proxy (..))
-import Hedgehog (forAll)
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -48,17 +46,17 @@ instance HasLogicalModel IntProp Int where
   satisfiesProperty IsSmall i = i <= 10 && i >= -10
 
 instance HasParameterisedGenerator IntProp Int where
-  parameterisedGenerator s = forAll $ do
+  parameterisedGenerator s = do
     i <-
       if IsZero `elem` s
         then pure 0
         else
           if IsSmall `elem` s
-            then Gen.int (linear 1 10)
+            then int (linear 1 10)
             else
               if IsMaxBound `elem` s
                 then pure maxBound
-                else Gen.int (linear 11 (maxBound -1))
+                else int (linear 11 (maxBound -1))
     if IsNegative `elem` s
       then
         if IsMinBound `elem` s

--- a/examples/Spec/IntPair.hs
+++ b/examples/Spec/IntPair.hs
@@ -52,10 +52,10 @@ instance HasPermutationGenerator IntPairProp (Int, Int) where
 instance HasParameterisedGenerator IntPairProp (Int, Int) where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen (Int, Int)
+baseGen :: Gen' (Int, Int)
 baseGen =
-  (,) <$> genSatisfying (Yes :: Formula IntProp)
-    <*> genSatisfying (Yes :: Formula IntProp)
+  (,) <$> (liftGen $ genSatisfying (Yes :: Formula IntProp))
+      <*> (liftGen $ genSatisfying (Yes :: Formula IntProp))
 
 intPairGenTests :: TestTree
 intPairGenTests =

--- a/examples/Spec/IntPermutationGen.hs
+++ b/examples/Spec/IntPermutationGen.hs
@@ -17,8 +17,6 @@ import Apropos.LogicalModel
 import Apropos.Pure
 import Apropos.Script
 import Data.Proxy (Proxy (..))
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear)
 import Plutarch (compile)
 import Plutarch.Prelude
 import Test.Tasty (TestTree, testGroup)
@@ -78,13 +76,13 @@ instance HasPermutationGenerator IntProp Int where
         { name = "MakeLarge"
         , match = Not $ Var IsLarge
         , contract = clear >> addAll [IsLarge, IsPositive]
-        , permuteGen = liftGenPA $ Gen.int (linear 11 (maxBound -1))
+        , permuteGen = int (linear 11 (maxBound -1))
         }
     , PermutationEdge
         { name = "MakeSmall"
         , match = Not $ Var IsSmall
         , contract = clear >> addAll [IsSmall, IsPositive]
-        , permuteGen = liftGenPA $ Gen.int (linear 1 10)
+        , permuteGen = int (linear 1 10)
         }
     , PermutationEdge
         { name = "Negate"
@@ -103,8 +101,8 @@ instance HasPermutationGenerator IntProp Int where
 instance HasParameterisedGenerator IntProp Int where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen Int
-baseGen = liftGenP $ Gen.int (linear minBound maxBound)
+baseGen :: Gen Int Int
+baseGen = int (linear minBound maxBound)
 
 intPermutationGenTests :: TestTree
 intPermutationGenTests =

--- a/examples/Spec/TicTacToe/Location.hs
+++ b/examples/Spec/TicTacToe/Location.hs
@@ -9,8 +9,6 @@ import Apropos.HasParameterisedGenerator
 import Apropos.HasPermutationGenerator
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.LogicalModel
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -36,17 +34,16 @@ instance HasPermutationGenerator LocationProperty Int where
         { name = "MakeLocationIsWithinBounds"
         , match = Var LocationIsOutOfBounds
         , contract = remove LocationIsOutOfBounds >> add LocationIsWithinBounds
-        , permuteGen = liftGenPA $ Gen.int (linear 0 8)
+        , permuteGen = int (linear 0 8)
         }
     , PermutationEdge
         { name = "MakeLocationIsOutOfBounds"
         , match = Var LocationIsWithinBounds
         , contract = remove LocationIsWithinBounds >> add LocationIsOutOfBounds
         , permuteGen =
-            liftGenPA $
-              Gen.choice $
-                [ Gen.int (linear minBound (-1))
-                , Gen.int (linear 9 maxBound)
+            choice $
+                [ int (linear minBound (-1))
+                , int (linear 9 maxBound)
                 ]
         }
     ]
@@ -54,8 +51,8 @@ instance HasPermutationGenerator LocationProperty Int where
 instance HasParameterisedGenerator LocationProperty Int where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen Int
-baseGen = liftGenP $ Gen.int (linear minBound maxBound)
+baseGen :: Gen' Int
+baseGen = int (linear minBound maxBound)
 
 locationPermutationGenSelfTest :: TestTree
 locationPermutationGenSelfTest =

--- a/examples/Spec/TicTacToe/Move.hs
+++ b/examples/Spec/TicTacToe/Move.hs
@@ -11,8 +11,6 @@ import Apropos.HasParameterisedGenerator
 import Apropos.HasPermutationGenerator
 import Apropos.LogicalModel
 import Control.Monad (join)
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear)
 import Spec.TicTacToe.Location
 import Spec.TicTacToe.Player
 import Test.Tasty (TestTree, testGroup)
@@ -49,10 +47,10 @@ instance HasPermutationGenerator MoveProperty (Int, Int) where
 instance HasParameterisedGenerator MoveProperty (Int, Int) where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen (Int, Int)
+baseGen :: Gen' (Int, Int)
 baseGen =
-  let g = Gen.int (linear minBound maxBound)
-   in liftGenP ((,) <$> g <*> g)
+  let g = int (linear minBound maxBound)
+   in (,) <$> g <*> g
 
 movePermutationGenSelfTest :: TestTree
 movePermutationGenSelfTest =
@@ -62,3 +60,4 @@ movePermutationGenSelfTest =
         True
         (\(_ :: PermutationEdge MoveProperty (Int, Int)) -> True)
         baseGen
+

--- a/examples/Spec/TicTacToe/Player.hs
+++ b/examples/Spec/TicTacToe/Player.hs
@@ -9,8 +9,6 @@ import Apropos.HasParameterisedGenerator
 import Apropos.HasPermutationGenerator
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.LogicalModel
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -52,20 +50,16 @@ instance HasPermutationGenerator PlayerProperty Int where
         { name = "MakePlayerInvalid"
         , match = Not $ Var PlayerIsInvalid
         , contract = removeAll [PlayerIsX, PlayerIsO] >> add PlayerIsInvalid
-        , permuteGen = do
-            p <-
-              liftGenPA $
-                Gen.filter (\i -> not (i `elem` [0, 1])) $
-                  Gen.int (linear minBound maxBound)
-            pure p
+        , permuteGen = genFilter (\i -> not (i `elem` [0, 1])) $
+                  int (linear minBound maxBound)
         }
     ]
 
 instance HasParameterisedGenerator PlayerProperty Int where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen Int
-baseGen = liftGenP $ Gen.int (linear minBound maxBound)
+baseGen :: Gen' Int
+baseGen = int (linear minBound maxBound)
 
 playerPermutationGenSelfTest :: TestTree
 playerPermutationGenSelfTest =

--- a/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
+++ b/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
@@ -11,8 +11,6 @@ import Apropos.HasParameterisedGenerator
 import Apropos.HasPermutationGenerator
 import Apropos.LogicalModel
 import Control.Monad (join)
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear, singleton)
 import Spec.TicTacToe.LocationSequence
 import Spec.TicTacToe.PlayerSequence
 import Test.Tasty (TestTree, testGroup)
@@ -66,11 +64,11 @@ instance HasPermutationGenerator PlayerLocationSequencePairProperty ([Int], [Int
 instance HasParameterisedGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen ([Int], [Int])
+baseGen :: Gen' ([Int], [Int])
 baseGen = do
-  l <- liftGenP $ Gen.int (linear 0 10)
-  l1 <- liftGenP $ Gen.list (singleton l) $ Gen.int (linear minBound maxBound)
-  l2 <- liftGenP $ Gen.list (singleton l) $ Gen.int (linear minBound maxBound)
+  l <- int (linear 0 10)
+  l1 <- list (singleton l) $ int (linear minBound maxBound)
+  l2 <- list (singleton l) $ int (linear minBound maxBound)
   pure (l1, l2)
 
 playerLocationSequencePairPermutationGenSelfTest :: TestTree

--- a/examples/Spec/TicTacToe/PlayerSequence.hs
+++ b/examples/Spec/TicTacToe/PlayerSequence.hs
@@ -9,8 +9,6 @@ import Apropos.HasParameterisedGenerator
 import Apropos.HasPermutationGenerator
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.LogicalModel
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear, singleton)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -65,7 +63,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
         , permuteGen = do
             s <- source
             let numMoves = min 9 (max 2 (length s))
-            pattern <- liftGenPA $ Gen.element [[0, 1], [1, 0]]
+            pattern <- element [[0, 1], [1, 0]]
             pure $ take numMoves (cycle pattern)
         }
     , PermutationEdge
@@ -83,7 +81,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
                 ]
         , permuteGen = do
             let numMoves = 10
-            pattern <- liftGenPA $ Gen.element [[0, 1], [1, 0]]
+            pattern <- element [[0, 1], [1, 0]]
             pure $ take numMoves (cycle pattern)
         }
     , PermutationEdge
@@ -101,11 +99,10 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
             removeAll [TakeTurns, PlayerSequenceNull]
               >> addAll [Don'tTakeTurns, PlayerSequenceSingleton]
         , permuteGen = do
-            liftGenPA $
-              Gen.list (singleton 1) $
-                Gen.choice
-                  [ Gen.int (linear minBound (-1))
-                  , Gen.int (linear 2 maxBound)
+            list (singleton 1) $
+                choice
+                  [ int (linear minBound (-1))
+                  , int (linear 2 maxBound)
                   ]
         }
     , PermutationEdge
@@ -115,7 +112,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
             removeAll [Don'tTakeTurns, PlayerSequenceNull]
               >> addAll [TakeTurns, PlayerSequenceSingleton]
         , permuteGen = do
-            liftGenPA $ Gen.list (singleton 1) $ Gen.int (linear 0 1)
+            list (singleton 1) $ int (linear 0 1)
         }
     , PermutationEdge
         { name = "MakeDon'tTakeTurns"
@@ -127,22 +124,22 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
             s <- source
             let numMoves = max 2 (length s)
             let genFoulPlay = do
-                  Gen.filter (satisfiesProperty Don'tTakeTurns) $
-                    Gen.list (singleton numMoves) $
-                      Gen.int (linear 0 1)
+                  genFilter (satisfiesProperty Don'tTakeTurns) $
+                    list (singleton numMoves) $
+                      int (linear 0 1)
                 genInvalid = do
-                  Gen.filter (satisfiesProperty Don'tTakeTurns) $
-                    Gen.list (singleton numMoves) $
-                      Gen.int (linear minBound maxBound)
-            liftGenPA $ Gen.choice [genFoulPlay, genInvalid]
+                  genFilter (satisfiesProperty Don'tTakeTurns) $
+                    list (singleton numMoves) $
+                      int (linear minBound maxBound)
+            choice [genFoulPlay, genInvalid]
         }
     ]
 
 instance HasParameterisedGenerator PlayerSequenceProperty [Int] where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen [Int]
-baseGen = liftGenP $ Gen.list (linear 0 10) $ Gen.int (linear minBound maxBound)
+baseGen :: Gen' [Int]
+baseGen = list (linear 0 10) $ int (linear minBound maxBound)
 
 playerSequencePermutationGenSelfTest :: TestTree
 playerSequencePermutationGenSelfTest =

--- a/src/Apropos/Gen.hs
+++ b/src/Apropos/Gen.hs
@@ -1,54 +1,232 @@
 module Apropos.Gen (
-  PAGen,
-  PGen,
-  source,
-  runGenPA,
-  liftGenPA,
-  liftGenP,
-  list,
-  listPA,
-  filterPA,
-) where
+  Gen,
+  Gen',
+  GenException,
+  genProp,
+  genRoot,
+  handleRootRetries,
 
+  source,
+  label,
+  failWithFootnote,
+  liftEdge,
+  liftGen,
+  bool,
+  int,
+  list,
+  shuffle,
+  element,
+  choice,
+
+  genFilter,
+  retry,
+
+  Range,
+  linear,
+  singleton,
+) where
+import Control.Monad.Free
+import Control.Monad (void)
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
-import Hedgehog (Gen, PropertyT, Range, forAll)
-import qualified Hedgehog.Gen as Gen
+import Control.Monad.Trans.Except (ExceptT,throwE,runExceptT)
+import Hedgehog (PropertyT,Property)
+import qualified Hedgehog as H
+import qualified Hedgehog.Gen as HGen
+import qualified Hedgehog.Range as HRange
+import Data.String (fromString)
 
-type PAGen m r = ReaderT m (PropertyT IO) r
-type PGen r = PropertyT IO r
+data Range = Linear Int Int | Singleton Int
 
-source :: PAGen m m
-source = ask
+linear :: Int -> Int -> Range
+linear a b = Linear a b
 
-runGenPA :: forall m r. PAGen m r -> m -> PGen r
-runGenPA g m = runReaderT g m
+singleton :: Int -> Range
+singleton s = Singleton s
 
-liftGenPA :: Show r => Gen r -> PAGen m r
-liftGenPA = lift . forAll
+--rangeSize :: Range -> Int
+--rangeSize (Singleton _) = 1
+--rangeSize (Linear lo hi) = 1 + fromIntegral (max 0 (hi - lo))
+--
+--rangeHi :: Range -> Int
+--rangeHi (Singleton s) = fromIntegral s
+--rangeHi (Linear _ hi) = fromIntegral hi
+--
+--rangeLo :: Range -> Int
+--rangeLo (Singleton s) = fromIntegral s
+--rangeLo (Linear lo _) = fromIntegral lo
 
-liftGenP :: Show r => Gen r -> PGen r
-liftGenP = forAll
+hRange :: Range -> H.Range Int
+hRange (Singleton s) = HRange.singleton s
+hRange (Linear lo hi) = HRange.linear lo hi
 
-list :: Range Int -> PGen r -> PAGen m [r]
-list range gen = do
-  l <- liftGenPA $ Gen.int range
-  sequence $ replicate l (lift gen)
+data FreeGen m next where
+  ReadGenInput :: forall m next . (m -> next)  -> FreeGen m next
+  LiftEdge :: forall m n next . Gen n n -> n -> (n -> next) -> FreeGen m next
+  LiftGen :: forall m n next . Gen n n -> (n -> next) -> FreeGen m next
+  Label :: String -> next -> FreeGen m next
+  FailWithFootnote :: forall a m next . String -> (a -> next) -> FreeGen m next
+  GenBool :: (Bool -> next) -> FreeGen m next
+  GenInt :: Range -> (Int -> next) -> FreeGen m next
+  GenList :: forall m a next .
+    Range -> (Gen m a) -> ([a] -> next) -> FreeGen m next
+  GenShuffle :: forall m a next . Show a =>
+    [a] -> ([a] -> next) -> FreeGen m next
+  GenElement :: forall m a next . Show a =>
+    [a] -> (a -> next) -> FreeGen m next
+  GenChoice :: forall m a next .
+    [Gen m a] -> (a -> next) -> FreeGen m next
+  GenFilter :: forall a m next . Show a =>
+    (a -> Bool) -> (Gen m a) -> (a -> next) -> FreeGen m next
+  RootRetry :: forall a m next . (a -> next) -> FreeGen m next
 
-listPA :: Range Int -> PAGen m r -> PAGen m [r]
-listPA range gen = do
-  l <- liftGenPA $ Gen.int range
-  sequence $ replicate l gen
+instance Functor (FreeGen m) where
+  fmap f (ReadGenInput next) = ReadGenInput (f . next)
+  fmap f (LiftEdge e i next) = LiftEdge e i (f . next)
+  fmap f (LiftGen g next) = LiftGen g (f . next)
+  fmap f (Label l next) = Label l (f next)
+  fmap f (FailWithFootnote l next) = FailWithFootnote l (f . next)
+  fmap f (GenBool next) = GenBool (f . next)
+  fmap f (GenInt r next) = GenInt r (f . next)
+  fmap f (GenList r g next) = GenList r g (f . next)
+  fmap f (GenShuffle l next) = GenShuffle l (f . next)
+  fmap f (GenElement ls next) = GenElement ls (f . next)
+  fmap f (GenChoice gs next) = GenChoice gs (f . next)
+  fmap f (GenFilter c g next) = GenFilter c g (f . next)
+  fmap f (RootRetry next) = RootRetry (f . next)
 
-filterPA :: forall m r. (r -> Bool) -> PAGen m r -> PAGen m r
-filterPA condition g = go 100
+
+type Gen p = Free (FreeGen p)
+
+type Gen' p = Gen p p
+
+source :: Gen m m
+source = liftF (ReadGenInput id)
+
+liftEdge :: Gen n n -> n -> Gen m n
+liftEdge e i = liftF (LiftEdge e i id)
+
+liftGen :: Gen n n -> Gen m n
+liftGen g = liftF (LiftGen g id)
+
+label :: String -> Gen m ()
+label s = liftF (Label s ())
+
+failWithFootnote :: String -> Gen m a
+failWithFootnote s = liftF (FailWithFootnote s id)
+
+bool :: Gen m Bool
+bool = liftF (GenBool id)
+
+int :: Range -> Gen m Int
+int r = liftF (GenInt r id)
+
+list :: Range -> Gen m a -> Gen m [a]
+list r g = liftF (GenList r g id)
+
+shuffle :: Show a => [a] -> Gen m [a]
+shuffle l = liftF (GenShuffle l id)
+
+element :: Show a => [a] -> Gen m a
+element l = liftF (GenElement l id)
+
+choice :: [Gen m a] -> Gen m a
+choice g = liftF (GenChoice g id)
+
+genFilter :: Show a => (a -> Bool) -> Gen m a -> Gen m a
+genFilter c g = liftF (GenFilter c g id)
+
+retry :: Gen m a
+retry = liftF (RootRetry id)
+
+genProp :: Gen m a -> Property
+genProp g = H.property $ void $ runExceptT (genRoot g)
+
+genRoot :: Gen m a -> ExceptT GenException (PropertyT IO) a
+genRoot g = runReaderT (gen g) Nothing
+
+data GenException = GenException String | Retry deriving stock (Show)
+
+type GenContext = PropertyT IO
+
+type Generator = ExceptT GenException GenContext
+
+type GenMorphism m a = ReaderT (Maybe m) Generator a
+
+gen :: forall m a . Gen m a -> GenMorphism m a
+gen (Free (ReadGenInput next)) = do
+  m <- ask
+  case m of
+    Nothing -> lift $ throwE $ GenException "can't read input in root gen"
+    Just so -> gen $ next so
+gen (Free (LiftEdge e i next)) = lift (genEdge e i) >>>= next
+gen (Free (LiftGen g next)) = lift (genRoot g) >>>= next
+gen (Free (Label s next)) = H.label (fromString s) >> gen next
+gen (Free (FailWithFootnote s _)) = H.footnote s >> H.failure
+gen (Free (GenBool next)) = (lift $ lift $ H.forAll $ HGen.bool) >>= (gen . next)
+gen (Free (GenInt r next)) = do
+  i <- lift $ lift (H.forAll $ HGen.int (hRange r))
+  gen $ next i
+gen (Free (GenList r g next)) = do
+  let gs = int r >>= \l -> sequence $ replicate l g
+  gen gs >>>= next
+gen (Free (GenShuffle ls next)) = do
+  s <- lift $ lift $ H.forAll $ HGen.shuffle ls
+  gen $ next s
+gen (Free (GenElement ls next)) = do
+  s <- lift $ lift $ H.forAll $ HGen.element ls
+  gen $ next s
+gen (Free (GenChoice gs next)) = do
+  let l = length gs
+  if l == 0
+     then lift $ throwE $ GenException "GenChoice: list length zero"
+     else do
+       i <- lift $ lift (H.forAll $ HGen.int (HRange.linear 0 (l-1)))
+       (gs!!i) >>== next
+gen (Free (GenFilter c g next)) = do
+  genFilter' c g >>>= next
+gen (Free (RootRetry _)) = lift $ throwE Retry
+gen (Pure a) = pure a
+
+
+(>>==) :: Gen m r -> (r -> Gen m a) -> GenMorphism m a
+(>>==) a b = do
+  m <- ask
+  r <- lift $ lift (runExceptT (runReaderT (gen a) m))
+  case r of
+    Right x -> gen $ b x
+    Left e -> lift $ throwE e
+
+(>>>=) :: GenMorphism m r -> (r -> Gen m a) -> GenMorphism m a
+(>>>=) a b = do
+  m <- ask
+  r <- lift $ lift (runExceptT (runReaderT a m))
+  case r of
+    Right x -> gen $ b x
+    Left e -> lift $ throwE e
+
+handleRootRetries :: Int -> Generator a -> GenContext a
+handleRootRetries 0 _ = H.footnote ("global retry limit reached reached") >> H.failure
+handleRootRetries l g = do
+  gr <- runExceptT g
+  case gr of
+    Right a -> pure a
+    Left Retry -> handleRootRetries (l-1) g
+    Left (GenException e) -> H.footnote e >> H.failure
+
+genEdge :: Gen m a -> m -> Generator a
+genEdge g m = runReaderT (gen g) (Just m)
+
+genFilter' :: forall m r. (r -> Bool) -> Gen m r -> GenMorphism m r
+genFilter' condition g = go 100
   where
-    go :: Int -> PAGen m r
-    go limit = do
-      if limit < 0
-        then error "filterPA: Tried 100 samples and rejected them all."
-        else pure ()
-      res <- g
-      if condition res
-        then pure res
-        else go (limit -1)
+    go :: Int -> GenMorphism m r
+    go l = do
+      if l < 0
+        then lift $ throwE Retry
+        else do
+          res <- gen g
+          if condition res
+            then pure res
+            else go (l -1)
+

--- a/src/Apropos/HasParameterisedGenerator.hs
+++ b/src/Apropos/HasParameterisedGenerator.hs
@@ -1,5 +1,8 @@
 module Apropos.HasParameterisedGenerator (
   HasParameterisedGenerator (..),
+  runGeneratorTest,
+  runGeneratorTestsWhere,
+  genSatisfying,
 ) where
 
 import Apropos.Gen
@@ -9,25 +12,35 @@ import Data.Proxy (Proxy)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.String (fromString)
-import Hedgehog (Group (..), Property, forAll, label, property, (===))
-import qualified Hedgehog.Gen as Gen
+import Hedgehog (Group (..), Property, property, (===))
+import Data.Proxy (Proxy (..))
 
 class (HasLogicalModel p m, Show m) => HasParameterisedGenerator p m where
-  parameterisedGenerator :: Set p -> PGen m
+  parameterisedGenerator :: Set p -> Gen m m
+  rootRetryLimit :: Proxy (m,p) -> Int
+  rootRetryLimit _ = 100
 
-  --TODO caching calls to the solver in genSatisfying would probably be worth it
-  genSatisfying :: Formula p -> PGen m
-  genSatisfying f = do
-    label $ fromString $ show f
-    s <- forAll $ Gen.element (enumerateScenariosWhere f)
-    parameterisedGenerator s
-  runGeneratorTest :: Proxy m -> Set p -> Property
-  runGeneratorTest _ s = property $ do
-    (m :: m) <- parameterisedGenerator s
-    properties m === s
-  runGeneratorTestsWhere :: Proxy m -> String -> Formula p -> Group
-  runGeneratorTestsWhere proxy name condition =
-    Group (fromString name) $
-      [ (fromString $ show $ Set.toList scenario, runGeneratorTest proxy scenario)
-      | scenario <- enumerateScenariosWhere condition
-      ]
+--TODO caching calls to the solver in genSatisfying would probably be worth it
+runGeneratorTest :: forall p m . HasParameterisedGenerator p m
+                 => Proxy m -> Set p -> Property
+runGeneratorTest _ s = property $ do
+  (m :: m) <- handleRootRetries numRetries $ genRoot $ parameterisedGenerator s
+  properties m === s
+    where
+      numRetries :: Int
+      numRetries = rootRetryLimit (Proxy :: Proxy (m,p))
+
+runGeneratorTestsWhere :: HasParameterisedGenerator p m
+                       => Proxy m -> String -> Formula p -> Group
+runGeneratorTestsWhere proxy name condition =
+  Group (fromString name) $
+    [ (fromString $ show $ Set.toList scenario, runGeneratorTest proxy scenario)
+    | scenario <- enumerateScenariosWhere condition
+    ]
+
+genSatisfying :: HasParameterisedGenerator p m => Formula p -> Gen' m
+genSatisfying f = do
+  label $ fromString $ show f
+  s <- element (enumerateScenariosWhere f)
+  liftGen $ parameterisedGenerator s
+

--- a/src/Apropos/HasPermutationGenerator/Abstraction.hs
+++ b/src/Apropos/HasPermutationGenerator/Abstraction.hs
@@ -13,8 +13,6 @@ import Apropos.Gen
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Either (rights)
-import Control.Monad.Trans (lift)
-import Control.Monad.Trans.Reader (ask) --TODO refactor gen monad abstraction
 import Control.Lens
 
 data Abstraction ap am bp bm =
@@ -34,9 +32,9 @@ abstract abstraction edge =
   , contract = abstractContract (abstractionName abstraction)
                                 (propertyAbstraction abstraction) $ contract edge
   , permuteGen = do
-        m <- ask
+        m <- source
         let n = m ^. (modelAbstraction abstraction)
-        nn <- lift $ runGenPA (permuteGen edge) n
+        nn <- liftEdge (permuteGen edge) n --TODO make retry limit configurable
         pure $ (modelAbstraction abstraction) .~ nn $ m
   }
 
@@ -77,9 +75,9 @@ composeEdges a b =
     , match = match a :&&: match b
     , contract = contract a >> contract b
     , permuteGen = do
-        m <- ask
-        ma <- lift $ runGenPA (permuteGen a) m
-        lift $ runGenPA (permuteGen b) ma
+        m <- source
+        ma <- liftEdge (permuteGen a) m
+        liftEdge (permuteGen b) ma
     }
 
 

--- a/src/Apropos/HasPermutationGenerator/PermutationEdge.hs
+++ b/src/Apropos/HasPermutationGenerator/PermutationEdge.hs
@@ -12,7 +12,7 @@ data PermutationEdge p m = PermutationEdge
   { name :: String
   , match :: Formula p
   , contract :: Contract p ()
-  , permuteGen :: PAGen m m
+  , permuteGen :: Gen m m
   }
 
 instance Eq (PermutationEdge p m) where


### PR DESCRIPTION
Free monad interface for Gen - this means the interface is now well decoupled from the Hedgehog API.
Supports retries - we can give up on generation and restart from the root generator.
Supports enhanced filter - tries filtering the local generator and falls back on retry.

These enhancements speed up the tests a lot. This is mostly because there are some examples using genSatisfying to implement retry which causes lots of calls to the SAT solver - implementing retry with ExceptT is much faster.