### PR TITLE
Fraser/refactor morphism

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,4 +11,5 @@
 - Create road plan for `apropos-plutus` standard library models
   - having a shared library of specifications could make the library more usable
   - this shared library might be best developed by encouraging upstreaming from library users
-
+- Collect space size statistics from generators. Generate 1000 values or so and filter identical values - this could be an interesting statistic. If we have generators that only produce a small number of values for some parameterisation we could reduce the number of tests for that space, flag this as a notable statistic that may indicate a problem, perhaps other use cases or statistics could be found.
+- Attach weights to propositions such that we can modulate the number of tests in each property based on these weights. We could allow user specified importance weightings and combine these with weights derived from distribution introspection as described above.This will allow the user to express importance and stop us wasting cycles on generators that have exhausted their space.

--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -41,6 +41,7 @@ common lang
                     , containers
                     , hedgehog
                     , free
+                    , lens
                     , minisat-solver
                     , mtl
                     , plutarch
@@ -67,6 +68,7 @@ library
                  , Apropos.HasLogicalModel
                  , Apropos.HasParameterisedGenerator
                  , Apropos.HasPermutationGenerator
+                 , Apropos.HasPermutationGenerator.Abstraction
                  , Apropos.HasPermutationGenerator.Contract
                  , Apropos.HasPermutationGenerator.PermutationEdge
                  , Apropos.Gen

--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -61,7 +61,9 @@ common lang
 
 library
   import:          lang
-  exposed-modules: Apropos.LogicalModel
+  exposed-modules: Apropos
+                 , Apropos.Type
+                 , Apropos.LogicalModel
                  , Apropos.LogicalModel.Formula
                  , Apropos.LogicalModel.Enumerable
                  , Apropos.LogicalModel.Enumerable.TH

--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -72,7 +72,7 @@ library
                  , Apropos.HasPermutationGenerator
                  , Apropos.HasPermutationGenerator.Abstraction
                  , Apropos.HasPermutationGenerator.Contract
-                 , Apropos.HasPermutationGenerator.PermutationEdge
+                 , Apropos.HasPermutationGenerator.Morphism
                  , Apropos.Gen
                  , Apropos.Pure
                  , Apropos.Script

--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -40,6 +40,7 @@ common lang
   build-depends:      base ^>=4.14
                     , containers
                     , hedgehog
+                    , free
                     , minisat-solver
                     , mtl
                     , plutarch

--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -74,6 +74,8 @@ library
                  , Apropos.HasPermutationGenerator.Contract
                  , Apropos.HasPermutationGenerator.Morphism
                  , Apropos.Gen
+                 , Apropos.Gen.Range
+                 , Apropos.Gen.Cardinality
                  , Apropos.Pure
                  , Apropos.Script
                  , Apropos.Tx

--- a/examples/Spec/Int.hs
+++ b/examples/Spec/Int.hs
@@ -7,10 +7,8 @@ import Apropos.HasParameterisedGenerator
 import Apropos.LogicalModel
 import Apropos.Pure
 import Apropos.Script
+import Apropos.Gen
 import Data.Proxy (Proxy (..))
-import Hedgehog (forAll)
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -48,17 +46,17 @@ instance HasLogicalModel IntProp Int where
   satisfiesProperty IsSmall i = i <= 10 && i >= -10
 
 instance HasParameterisedGenerator IntProp Int where
-  parameterisedGenerator s = forAll $ do
+  parameterisedGenerator s = do
     i <-
       if IsZero `elem` s
         then pure 0
         else
           if IsSmall `elem` s
-            then Gen.int (linear 1 10)
+            then int (linear 1 10)
             else
               if IsMaxBound `elem` s
                 then pure maxBound
-                else Gen.int (linear 11 (maxBound -1))
+                else int (linear 11 (maxBound -1))
     if IsNegative `elem` s
       then
         if IsMinBound `elem` s

--- a/examples/Spec/Int.hs
+++ b/examples/Spec/Int.hs
@@ -1,14 +1,8 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Spec.Int (HasLogicalModel (..), IntProp (..), intGenTests, intPureTests, intPlutarchTests) where
-
-import Apropos.HasLogicalModel
-import Apropos.HasParameterisedGenerator
-import Apropos.LogicalModel
-import Apropos.Pure
+import Apropos
 import Apropos.Script
-import Apropos.Gen
-import Data.Proxy (Proxy (..))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -68,7 +62,7 @@ intGenTests :: TestTree
 intGenTests =
   testGroup "intGenTests" $
     fromGroup
-      <$> [ runGeneratorTestsWhere (Proxy :: Proxy Int) "Int Generator" (Yes :: Formula IntProp)
+      <$> [ runGeneratorTestsWhere (Apropos :: Int :+ IntProp) "Int Generator" Yes
           ]
 
 instance HasPureRunner IntProp Int where
@@ -79,11 +73,11 @@ intPureTests :: TestTree
 intPureTests =
   testGroup "intPureTests" $
     fromGroup
-      <$> [ runPureTestsWhere (Proxy :: Proxy Int) "AcceptsSmallNegativeInts" (Yes :: Formula IntProp)
+      <$> [ runPureTestsWhere (Apropos :: Int :+ IntProp) "AcceptsSmallNegativeInts" Yes
           ]
 
 instance HasScriptRunner IntProp Int where
-  expect _ _ = Var IsSmall :&&: Var IsNegative
+  expect _ = Var IsSmall :&&: Var IsNegative
   script _ i =
     let ii = (fromIntegral i) :: Integer
      in compile (pif (((fromInteger ii) #< ((fromInteger 0) :: Term s PInteger)) #&& (((fromInteger (-10)) :: Term s PInteger) #<= (fromInteger ii))) (pcon PUnit) perror)
@@ -92,5 +86,5 @@ intPlutarchTests :: TestTree
 intPlutarchTests =
   testGroup "intPlutarchTests" $
     fromGroup
-      <$> [ runScriptTestsWhere (Proxy :: Proxy Int) (Proxy :: Proxy IntProp) "AcceptsSmallNegativeInts" Yes
+      <$> [ runScriptTestsWhere (Apropos :: Int :+ IntProp) "AcceptsSmallNegativeInts" Yes
           ]

--- a/examples/Spec/IntPair.hs
+++ b/examples/Spec/IntPair.hs
@@ -46,10 +46,10 @@ instance HasPermutationGenerator IntPairProp (Int, Int) where
 instance HasParameterisedGenerator IntPairProp (Int, Int) where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: Gen' (Int, Int)
+baseGen :: Gen (Int, Int)
 baseGen =
-  (,) <$> (liftGen $ genSatisfying (Yes :: Formula IntProp))
-      <*> (liftGen $ genSatisfying (Yes :: Formula IntProp))
+  (,) <$> (genSatisfying (Yes :: Formula IntProp))
+      <*> (genSatisfying (Yes :: Formula IntProp))
 
 intPairGenTests :: TestTree
 intPairGenTests =

--- a/examples/Spec/IntPair.hs
+++ b/examples/Spec/IntPair.hs
@@ -38,36 +38,23 @@ instance HasLogicalModel IntPairProp (Int, Int) where
 
 instance HasPermutationGenerator IntPairProp (Int, Int) where
   generators =
-    --TODO liftEdges could be prettier - we could use lenses to
-    --                                 -            get and set a substructure in the model
-    --                                 -            Maybe extract a subproperty from a property
-    --
-    --                                 - we could derive the prefix string from the property constructor
-    --
-    --                                 - then we would have a 4 argument function instead of a 6 argument function
-    let l =
-          liftEdges
-            L
-            fst
-            (\f (_, r') -> (f, r'))
-            ( \p -> case p of
-                (L q) -> Just q
-                _ -> Nothing
-            )
-            "L"
-            generators
-        r =
-          liftEdges
-            R
-            snd
-            (\f (l', _) -> (l', f))
-            ( \p -> case p of
-                (R q) -> Just q
-                _ -> Nothing
-            )
-            "R"
-            generators
-     in join [l, r]
+    let l = ModelAbstraction { abstractionName = "L"
+                             , projectProperty =  \p -> case p of
+                                                          (L q) -> Just q
+                                                          _ -> Nothing
+                             , injectProperty = L
+                             , projectSubmodel = fst
+                             , injectSubmodel = \f (_, r') -> (f, r')
+                             }
+        r = ModelAbstraction { abstractionName = "R"
+                             , projectProperty =  \p -> case p of
+                                                          (R q) -> Just q
+                                                          _ -> Nothing
+                             , injectProperty = R
+                             , projectSubmodel = snd
+                             , injectSubmodel = \f (l', _) -> (l', f)
+                             }
+     in join [l <$$> generators, r <$$> generators]
 
 instance HasParameterisedGenerator IntPairProp (Int, Int) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/IntPair.hs
+++ b/examples/Spec/IntPair.hs
@@ -52,10 +52,10 @@ instance HasPermutationGenerator IntPairProp (Int, Int) where
 instance HasParameterisedGenerator IntPairProp (Int, Int) where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen (Int, Int)
+baseGen :: Gen' (Int, Int)
 baseGen =
-  (,) <$> genSatisfying (Yes :: Formula IntProp)
-    <*> genSatisfying (Yes :: Formula IntProp)
+  (,) <$> (liftGen $ genSatisfying (Yes :: Formula IntProp))
+      <*> (liftGen $ genSatisfying (Yes :: Formula IntProp))
 
 intPairGenTests :: TestTree
 intPairGenTests =

--- a/examples/Spec/IntPair.hs
+++ b/examples/Spec/IntPair.hs
@@ -113,5 +113,5 @@ intPairGenSelfTests =
     fromGroup
       <$> permutationGeneratorSelfTest
         True
-        (\(_ :: PermutationEdge IntPairProp (Int, Int)) -> True)
+        (\(_ :: Morphism IntPairProp (Int, Int)) -> True)
         baseGen

--- a/examples/Spec/IntPair.hs
+++ b/examples/Spec/IntPair.hs
@@ -21,6 +21,7 @@ import Plutarch.Prelude
 import Spec.IntPermutationGen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
+import Control.Lens.Tuple(_1,_2)
 
 data IntPairProp
   = L IntProp
@@ -38,23 +39,15 @@ instance HasLogicalModel IntPairProp (Int, Int) where
 
 instance HasPermutationGenerator IntPairProp (Int, Int) where
   generators =
-    let l = ModelAbstraction { abstractionName = "L"
-                             , projectProperty =  \p -> case p of
-                                                          (L q) -> Just q
-                                                          _ -> Nothing
-                             , injectProperty = L
-                             , projectSubmodel = fst
-                             , injectSubmodel = \f (_, r') -> (f, r')
-                             }
-        r = ModelAbstraction { abstractionName = "R"
-                             , projectProperty =  \p -> case p of
-                                                          (R q) -> Just q
-                                                          _ -> Nothing
-                             , injectProperty = R
-                             , projectSubmodel = snd
-                             , injectSubmodel = \f (l', _) -> (l', f)
-                             }
-     in join [l <$$> generators, r <$$> generators]
+    let l = Abstraction { abstractionName = "L"
+                        , propertyAbstraction = abstractsProperties L
+                        , modelAbstraction = _1
+                        }
+        r = Abstraction { abstractionName = "R"
+                        , propertyAbstraction = abstractsProperties R
+                        , modelAbstraction = _2
+                        }
+     in join [abstract l <$> generators, abstract r <$> generators]
 
 instance HasParameterisedGenerator IntPairProp (Int, Int) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/IntPair.hs
+++ b/examples/Spec/IntPair.hs
@@ -6,16 +6,10 @@ module Spec.IntPair (
   intPairGenSelfTests,
   intPairGenPlutarchTests,
 ) where
-
-import Apropos.Gen
-import Apropos.HasLogicalModel
-import Apropos.HasParameterisedGenerator
-import Apropos.HasPermutationGenerator
-import Apropos.LogicalModel
-import Apropos.Pure
+import Apropos
 import Apropos.Script
+
 import Control.Monad (join)
-import Data.Proxy (Proxy (..))
 import Plutarch (compile)
 import Plutarch.Prelude
 import Spec.IntPermutationGen
@@ -61,29 +55,36 @@ intPairGenTests :: TestTree
 intPairGenTests =
   testGroup "intPairGenTests" $
     fromGroup
-      <$> [ runGeneratorTestsWhere (Proxy :: Proxy (Int, Int)) "(Int,Int) Generator" (Yes :: Formula IntPairProp)
+      <$> [ runGeneratorTestsWhere
+              (Apropos :: (Int, Int) :+ IntPairProp)
+              "(Int,Int) Generator"
+              Yes
           ]
 
 instance HasPureRunner IntPairProp (Int, Int) where
   expect _ =
     All $
-      Var
-        <$> ( join
-                [ L <$> [IsSmall, IsNegative]
-                , R <$> [IsSmall, IsPositive]
-                ]
-            )
-  script _ (l, r) = l < 0 && l >= -10 && r > 0 && r <= 10
+       Var
+         <$> ( join
+                 [ L <$> [IsSmall, IsNegative]
+                 , R <$> [IsSmall, IsPositive]
+                 ]
+             )
+  script _ (l,r) = l < 0 && l >= -10 && r > 0 && r <= 10
+
 
 intPairGenPureTests :: TestTree
 intPairGenPureTests =
   testGroup "intPairGenPureTests" $
     fromGroup
-      <$> [ runPureTestsWhere (Proxy :: Proxy (Int, Int)) "AcceptsLeftSmallNegativeRightSmallPositive" (Yes :: Formula IntPairProp)
+      <$> [ runPureTestsWhere
+              (Apropos :: (Int, Int) :+ IntPairProp)
+              "AcceptsLeftSmallNegativeRightSmallPositive"
+              Yes
           ]
 
 instance HasScriptRunner IntPairProp (Int, Int) where
-  expect _ _ =
+  expect _ =
     All $
       Var
         <$> ( join
@@ -100,7 +101,10 @@ intPairGenPlutarchTests :: TestTree
 intPairGenPlutarchTests =
   testGroup "intPairGenPlutarchTests" $
     fromGroup
-      <$> [ runScriptTestsWhere (Proxy :: Proxy (Int, Int)) (Proxy :: Proxy IntPairProp) "AcceptsLeftSmallNegativeRightSmallPositive" Yes
+      <$> [ runScriptTestsWhere
+              (Apropos :: (Int, Int) :+ IntPairProp)
+              "AcceptsLeftSmallNegativeRightSmallPositive"
+              Yes
           ]
 
 intPairGenSelfTests :: TestTree

--- a/examples/Spec/IntPermutationGen.hs
+++ b/examples/Spec/IntPermutationGen.hs
@@ -17,8 +17,6 @@ import Apropos.LogicalModel
 import Apropos.Pure
 import Apropos.Script
 import Data.Proxy (Proxy (..))
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear)
 import Plutarch (compile)
 import Plutarch.Prelude
 import Test.Tasty (TestTree, testGroup)
@@ -78,13 +76,13 @@ instance HasPermutationGenerator IntProp Int where
         { name = "MakeLarge"
         , match = Not $ Var IsLarge
         , contract = clear >> addAll [IsLarge, IsPositive]
-        , permuteGen = liftGenPA $ Gen.int (linear 11 (maxBound -1))
+        , permuteGen = int (linear 11 (maxBound -1))
         }
     , PermutationEdge
         { name = "MakeSmall"
         , match = Not $ Var IsSmall
         , contract = clear >> addAll [IsSmall, IsPositive]
-        , permuteGen = liftGenPA $ Gen.int (linear 1 10)
+        , permuteGen = int (linear 1 10)
         }
     , PermutationEdge
         { name = "Negate"
@@ -103,8 +101,8 @@ instance HasPermutationGenerator IntProp Int where
 instance HasParameterisedGenerator IntProp Int where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen Int
-baseGen = liftGenP $ Gen.int (linear minBound maxBound)
+baseGen :: Gen Int Int
+baseGen = int (linear minBound maxBound)
 
 intPermutationGenTests :: TestTree
 intPermutationGenTests =

--- a/examples/Spec/IntPermutationGen.hs
+++ b/examples/Spec/IntPermutationGen.hs
@@ -46,37 +46,37 @@ instance HasLogicalModel IntProp Int where
 
 instance HasPermutationGenerator IntProp Int where
   generators =
-    [ PermutationEdge
+    [ Morphism
         { name = "MakeZero"
         , match = Not $ Var IsZero
         , contract = clear >> addAll [IsZero, IsSmall]
-        , permuteGen = sink 0
+        , morphism = sink 0
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeMaxBound"
         , match = Not $ Var IsMaxBound
         , contract = clear >> addAll [IsMaxBound, IsLarge, IsPositive]
-        , permuteGen = sink maxBound
+        , morphism = sink maxBound
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeMinBound"
         , match = Not $ Var IsMinBound
         , contract = clear >> addAll [IsMinBound, IsLarge, IsNegative]
-        , permuteGen = sink minBound
+        , morphism = sink minBound
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeLarge"
         , match = Not $ Var IsLarge
         , contract = clear >> addAll [IsLarge, IsPositive]
-        , permuteGen = int (linear 11 (maxBound -1))
+        , morphism = int (linear 11 (maxBound -1))
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeSmall"
         , match = Not $ Var IsSmall
         , contract = clear >> addAll [IsSmall, IsPositive]
-        , permuteGen = int (linear 1 10)
+        , morphism = int (linear 1 10)
         }
-    , PermutationEdge
+    , Morphism
         { name = "Negate"
         , match = Not $ Var IsZero
         , contract =
@@ -84,7 +84,7 @@ instance HasPermutationGenerator IntProp Int where
               [ has IsNegative >> remove IsNegative >> add IsPositive
               , has IsPositive >> remove IsPositive >> add IsNegative
               ]
-        , permuteGen = do
+        , morphism = do
             i <- source
             sink (- i)
         }
@@ -133,5 +133,5 @@ intPermutationGenSelfTests =
     fromGroup
       <$> permutationGeneratorSelfTest
         True
-        (\(_ :: PermutationEdge IntProp Int) -> True)
+        (\(_ :: Morphism IntProp Int) -> True)
         baseGen

--- a/examples/Spec/IntPermutationGen.hs
+++ b/examples/Spec/IntPermutationGen.hs
@@ -50,31 +50,31 @@ instance HasPermutationGenerator IntProp Int where
         { name = "MakeZero"
         , match = Not $ Var IsZero
         , contract = clear >> addAll [IsZero, IsSmall]
-        , morphism = sink 0
+        , morphism = \_ -> pure 0
         }
     , Morphism
         { name = "MakeMaxBound"
         , match = Not $ Var IsMaxBound
         , contract = clear >> addAll [IsMaxBound, IsLarge, IsPositive]
-        , morphism = sink maxBound
+        , morphism = \_ -> pure maxBound
         }
     , Morphism
         { name = "MakeMinBound"
         , match = Not $ Var IsMinBound
         , contract = clear >> addAll [IsMinBound, IsLarge, IsNegative]
-        , morphism = sink minBound
+        , morphism = \_ -> pure minBound
         }
     , Morphism
         { name = "MakeLarge"
         , match = Not $ Var IsLarge
         , contract = clear >> addAll [IsLarge, IsPositive]
-        , morphism = int (linear 11 (maxBound -1))
+        , morphism = \_ -> int (linear 11 (maxBound -1))
         }
     , Morphism
         { name = "MakeSmall"
         , match = Not $ Var IsSmall
         , contract = clear >> addAll [IsSmall, IsPositive]
-        , morphism = int (linear 1 10)
+        , morphism = \_ -> int (linear 1 10)
         }
     , Morphism
         { name = "Negate"
@@ -84,16 +84,14 @@ instance HasPermutationGenerator IntProp Int where
               [ has IsNegative >> remove IsNegative >> add IsPositive
               , has IsPositive >> remove IsPositive >> add IsNegative
               ]
-        , morphism = do
-            i <- source
-            sink (- i)
+        , morphism = \i -> pure (- i)
         }
     ]
 
 instance HasParameterisedGenerator IntProp Int where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: Gen Int Int
+baseGen :: Gen Int
 baseGen = int (linear minBound maxBound)
 
 intPermutationGenTests :: TestTree

--- a/examples/Spec/Plutarch/CostModel.hs
+++ b/examples/Spec/Plutarch/CostModel.hs
@@ -4,10 +4,7 @@ module Spec.Plutarch.CostModel (
   addCostPropGenTests,
   addCostModelPlutarchTests,
 ) where
-
-import Apropos.HasLogicalModel
-import Apropos.HasParameterisedGenerator
-import Apropos.LogicalModel
+import Apropos
 import Apropos.Script
 
 import qualified Data.Set as Set
@@ -18,7 +15,6 @@ import Plutus.V1.Ledger.Scripts (Script)
 import Plutarch (compile)
 import Plutarch.Prelude
 
-import Data.Proxy (Proxy (..))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -59,14 +55,14 @@ addCostPropGenTests =
   testGroup "Spec.Plutarch.CostModel" $
     fromGroup
       <$> [ runGeneratorTestsWhere
-              (Proxy :: Proxy Integer)
+              (Apropos :: Integer :+ CostModelProp)
               "(+) Cost Model Script Generator"
-              (Yes :: Formula CostModelProp)
+              Yes
           ]
 
 instance HasScriptRunner CostModelProp Integer where
   script _ i = addCost i
-  expect _ _ = Yes :: Formula CostModelProp
+  expect _ = Yes :: Formula CostModelProp
 
   -- This is the cool bit. We can model the cost exactly. Neato.
   -- If we build a higherarchichal model we can compose these.
@@ -82,8 +78,7 @@ addCostModelPlutarchTests =
   testGroup "Plutarch.AdditionCostModel" $
     fromGroup
       <$> [ runScriptTestsWhere
-              (Proxy :: Proxy Integer)
-              (Proxy :: Proxy CostModelProp)
+              (Apropos :: Integer :+ CostModelProp)
               "AdditionCostModel"
               Yes
           ]

--- a/examples/Spec/Plutarch/MagicNumber.hs
+++ b/examples/Spec/Plutarch/MagicNumber.hs
@@ -3,10 +3,7 @@
 module Spec.Plutarch.MagicNumber (
   magicNumberPropGenTests,
 ) where
-
-import Apropos.HasLogicalModel
-import Apropos.HasParameterisedGenerator
-import Apropos.LogicalModel
+import Apropos
 
 import qualified Data.Set as Set
 
@@ -15,7 +12,6 @@ import Plutus.V1.Ledger.Scripts (Script)
 import Plutarch (compile)
 import Plutarch.Prelude
 
-import Data.Proxy (Proxy (..))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -61,7 +57,7 @@ magicNumberPropGenTests =
   testGroup "Spec.Plutarch.MagicNumber" $
     fromGroup
       <$> [ runGeneratorTestsWhere
-              (Proxy :: Proxy Script)
+              (Apropos :: Script :+ MagicNumberProp)
               "Magic Number Script Generator"
-              (Yes :: Formula MagicNumberProp)
+              Yes
           ]

--- a/examples/Spec/TicTacToe/Location.hs
+++ b/examples/Spec/TicTacToe/Location.hs
@@ -30,17 +30,17 @@ instance HasLogicalModel LocationProperty Int where
 
 instance HasPermutationGenerator LocationProperty Int where
   generators =
-    [ PermutationEdge
+    [ Morphism
         { name = "MakeLocationIsWithinBounds"
         , match = Var LocationIsOutOfBounds
         , contract = remove LocationIsOutOfBounds >> add LocationIsWithinBounds
-        , permuteGen = int (linear 0 8)
+        , morphism = int (linear 0 8)
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeLocationIsOutOfBounds"
         , match = Var LocationIsWithinBounds
         , contract = remove LocationIsWithinBounds >> add LocationIsOutOfBounds
-        , permuteGen =
+        , morphism =
             choice $
                 [ int (linear minBound (-1))
                 , int (linear 9 maxBound)
@@ -60,5 +60,5 @@ locationPermutationGenSelfTest =
     fromGroup
       <$> permutationGeneratorSelfTest
         True
-        (\(_ :: PermutationEdge LocationProperty Int) -> True)
+        (\(_ :: Morphism LocationProperty Int) -> True)
         baseGen

--- a/examples/Spec/TicTacToe/Location.hs
+++ b/examples/Spec/TicTacToe/Location.hs
@@ -9,8 +9,6 @@ import Apropos.HasParameterisedGenerator
 import Apropos.HasPermutationGenerator
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.LogicalModel
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -36,17 +34,16 @@ instance HasPermutationGenerator LocationProperty Int where
         { name = "MakeLocationIsWithinBounds"
         , match = Var LocationIsOutOfBounds
         , contract = remove LocationIsOutOfBounds >> add LocationIsWithinBounds
-        , permuteGen = liftGenPA $ Gen.int (linear 0 8)
+        , permuteGen = int (linear 0 8)
         }
     , PermutationEdge
         { name = "MakeLocationIsOutOfBounds"
         , match = Var LocationIsWithinBounds
         , contract = remove LocationIsWithinBounds >> add LocationIsOutOfBounds
         , permuteGen =
-            liftGenPA $
-              Gen.choice $
-                [ Gen.int (linear minBound (-1))
-                , Gen.int (linear 9 maxBound)
+            choice $
+                [ int (linear minBound (-1))
+                , int (linear 9 maxBound)
                 ]
         }
     ]
@@ -54,8 +51,8 @@ instance HasPermutationGenerator LocationProperty Int where
 instance HasParameterisedGenerator LocationProperty Int where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen Int
-baseGen = liftGenP $ Gen.int (linear minBound maxBound)
+baseGen :: Gen' Int
+baseGen = int (linear minBound maxBound)
 
 locationPermutationGenSelfTest :: TestTree
 locationPermutationGenSelfTest =

--- a/examples/Spec/TicTacToe/Location.hs
+++ b/examples/Spec/TicTacToe/Location.hs
@@ -34,13 +34,13 @@ instance HasPermutationGenerator LocationProperty Int where
         { name = "MakeLocationIsWithinBounds"
         , match = Var LocationIsOutOfBounds
         , contract = remove LocationIsOutOfBounds >> add LocationIsWithinBounds
-        , morphism = int (linear 0 8)
+        , morphism = \_ -> int (linear 0 8)
         }
     , Morphism
         { name = "MakeLocationIsOutOfBounds"
         , match = Var LocationIsWithinBounds
         , contract = remove LocationIsWithinBounds >> add LocationIsOutOfBounds
-        , morphism =
+        , morphism = \_ ->
             choice $
                 [ int (linear minBound (-1))
                 , int (linear 9 maxBound)
@@ -51,7 +51,7 @@ instance HasPermutationGenerator LocationProperty Int where
 instance HasParameterisedGenerator LocationProperty Int where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: Gen' Int
+baseGen :: Gen Int
 baseGen = int (linear minBound maxBound)
 
 locationPermutationGenSelfTest :: TestTree

--- a/examples/Spec/TicTacToe/LocationSequence.hs
+++ b/examples/Spec/TicTacToe/LocationSequence.hs
@@ -56,7 +56,7 @@ instance HasLogicalModel LocationSequenceProperty [Int] where
 
 instance HasPermutationGenerator LocationSequenceProperty [Int] where
   generators =
-    [ PermutationEdge
+    [ Morphism
         { name = "MakeLocationSequenceNull"
         , match = Yes
         , contract =
@@ -67,9 +67,9 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
               , LocationSequenceIsLongerThanGame
               ]
               >> addAll [AllLocationsAreInBounds, LocationSequenceIsNull]
-        , permuteGen = pure []
+        , morphism = pure []
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeAllLocationsAreInBoundsNoneOccupiedTwice"
         , match = Not $ Var LocationSequenceIsNull
         , contract =
@@ -79,13 +79,13 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
               , LocationSequenceIsLongerThanGame
               ]
               >> add AllLocationsAreInBounds
-        , permuteGen = do
+        , morphism = do
             locations <- source
             let locationsLen = min 9 (length locations)
             locations' <- shuffle [0 .. 8]
             pure $ take locationsLen locations'
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeAllLocationsAreInBoundsSomeOccupiedTwice"
         , match = Yes
         , contract =
@@ -97,14 +97,14 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
                 [ AllLocationsAreInBounds
                 , SomeLocationIsOccupiedTwice
                 ]
-        , permuteGen = do
+        , morphism = do
             locations <- source
             let locationsLen = max 2 (length locations)
             locations' <- shuffle [0 .. 8]
             let locations'' = take (locationsLen - 1) locations'
             list (singleton locationsLen) $ element locations''
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeOutOfBoundsSingleton"
         , match = Yes
         , contract =
@@ -115,14 +115,14 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
               , LocationSequenceIsLongerThanGame
               ]
               >> addAll [SomeLocationIsOutOfBounds, LocationSequenceIsSingleton]
-        , permuteGen =
+        , morphism =
             list (singleton 1) $
               choice
                   [ int (linear minBound (-1))
                   , int (linear 9 maxBound)
                   ]
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeInBoundsSingleton"
         , match = Yes
         , contract =
@@ -133,10 +133,10 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
               , LocationSequenceIsLongerThanGame
               ]
               >> addAll [AllLocationsAreInBounds, LocationSequenceIsSingleton]
-        , permuteGen =
+        , morphism =
             list (singleton 1) $ int (linear 0 8)
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeSomeLocationIsOutOfBoundsNoneOccupiedTwice"
         , match = Not $ Var LocationSequenceIsNull
         , contract =
@@ -145,7 +145,7 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
               , SomeLocationIsOccupiedTwice
               ]
               >> add SomeLocationIsOutOfBounds
-        , permuteGen =
+        , morphism =
             let f =
                   ( \m ->
                       satisfiesFormula
@@ -161,7 +161,7 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
                       list (singleton locationsLen) $
                         int (linear minBound maxBound)
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeSomeLocationIsOccupiedTwiceSequenceTooLong"
         , match = Not (Var LocationSequenceIsNull :||: Var LocationSequenceIsSingleton)
         , contract =
@@ -175,13 +175,13 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
                 , SomeLocationIsOutOfBounds
                 , LocationSequenceIsLongerThanGame
                 ]
-        , permuteGen = genFilter (satisfiesProperty SomeLocationIsOutOfBounds) $ do
+        , morphism = genFilter (satisfiesProperty SomeLocationIsOutOfBounds) $ do
             let locationsLen = 10
             locations' <- list (singleton (locationsLen - 1)) $
                   int (linear minBound maxBound)
             list (singleton locationsLen) $ element locations'
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeSomeLocationIsOccupiedTwice"
         , match = Not (Var LocationSequenceIsNull :||: Var LocationSequenceIsSingleton)
         , contract =
@@ -194,7 +194,7 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
                 [ SomeLocationIsOccupiedTwice
                 , SomeLocationIsOutOfBounds
                 ]
-        , permuteGen = genFilter (satisfiesProperty SomeLocationIsOutOfBounds) $ do
+        , morphism = genFilter (satisfiesProperty SomeLocationIsOutOfBounds) $ do
             locations <- source
             let locationsLen = length locations
             locations' <- list (singleton (locationsLen - 1)) $
@@ -217,5 +217,5 @@ locationSequencePermutationGenSelfTest =
     fromGroup
       <$> permutationGeneratorSelfTest
         True
-        (\(_ :: PermutationEdge LocationSequenceProperty [Int]) -> True)
+        (\(_ :: Morphism LocationSequenceProperty [Int]) -> True)
         baseGen

--- a/examples/Spec/TicTacToe/LocationSequence.hs
+++ b/examples/Spec/TicTacToe/LocationSequence.hs
@@ -67,7 +67,7 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
               , LocationSequenceIsLongerThanGame
               ]
               >> addAll [AllLocationsAreInBounds, LocationSequenceIsNull]
-        , morphism = pure []
+        , morphism = \_ -> pure []
         }
     , Morphism
         { name = "MakeAllLocationsAreInBoundsNoneOccupiedTwice"
@@ -79,8 +79,7 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
               , LocationSequenceIsLongerThanGame
               ]
               >> add AllLocationsAreInBounds
-        , morphism = do
-            locations <- source
+        , morphism = \locations -> do
             let locationsLen = min 9 (length locations)
             locations' <- shuffle [0 .. 8]
             pure $ take locationsLen locations'
@@ -97,8 +96,7 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
                 [ AllLocationsAreInBounds
                 , SomeLocationIsOccupiedTwice
                 ]
-        , morphism = do
-            locations <- source
+        , morphism = \locations -> do
             let locationsLen = max 2 (length locations)
             locations' <- shuffle [0 .. 8]
             let locations'' = take (locationsLen - 1) locations'
@@ -115,7 +113,7 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
               , LocationSequenceIsLongerThanGame
               ]
               >> addAll [SomeLocationIsOutOfBounds, LocationSequenceIsSingleton]
-        , morphism =
+        , morphism = \_ ->
             list (singleton 1) $
               choice
                   [ int (linear minBound (-1))
@@ -133,8 +131,7 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
               , LocationSequenceIsLongerThanGame
               ]
               >> addAll [AllLocationsAreInBounds, LocationSequenceIsSingleton]
-        , morphism =
-            list (singleton 1) $ int (linear 0 8)
+        , morphism = \_ -> list (singleton 1) $ int (linear 0 8)
         }
     , Morphism
         { name = "MakeSomeLocationIsOutOfBoundsNoneOccupiedTwice"
@@ -145,7 +142,7 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
               , SomeLocationIsOccupiedTwice
               ]
               >> add SomeLocationIsOutOfBounds
-        , morphism =
+        , morphism = \locations ->
             let f =
                   ( \m ->
                       satisfiesFormula
@@ -155,7 +152,6 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
                         (properties m)
                   )
              in do
-                  locations <- source
                   let locationsLen = length locations
                   genFilter f $
                       list (singleton locationsLen) $
@@ -175,11 +171,11 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
                 , SomeLocationIsOutOfBounds
                 , LocationSequenceIsLongerThanGame
                 ]
-        , morphism = genFilter (satisfiesProperty SomeLocationIsOutOfBounds) $ do
-            let locationsLen = 10
-            locations' <- list (singleton (locationsLen - 1)) $
-                  int (linear minBound maxBound)
-            list (singleton locationsLen) $ element locations'
+        , morphism = \_ -> genFilter (satisfiesProperty SomeLocationIsOutOfBounds) $ do
+                             let locationsLen = 10
+                             locations' <- list (singleton (locationsLen - 1)) $
+                                   int (linear minBound maxBound)
+                             list (singleton locationsLen) $ element locations'
         }
     , Morphism
         { name = "MakeSomeLocationIsOccupiedTwice"
@@ -194,19 +190,18 @@ instance HasPermutationGenerator LocationSequenceProperty [Int] where
                 [ SomeLocationIsOccupiedTwice
                 , SomeLocationIsOutOfBounds
                 ]
-        , morphism = genFilter (satisfiesProperty SomeLocationIsOutOfBounds) $ do
-            locations <- source
-            let locationsLen = length locations
-            locations' <- list (singleton (locationsLen - 1)) $
-                  int (linear minBound maxBound)
-            list (singleton locationsLen) $ element locations'
+        , morphism = \locations -> genFilter (satisfiesProperty SomeLocationIsOutOfBounds) $ do
+                             let locationsLen = length locations
+                             locations' <- list (singleton (locationsLen - 1)) $
+                                   int (linear minBound maxBound)
+                             list (singleton locationsLen) $ element locations'
         }
     ]
 
 instance HasParameterisedGenerator LocationSequenceProperty [Int] where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: Gen' [Int]
+baseGen :: Gen [Int]
 baseGen =
   let g = int (linear minBound maxBound)
    in list (linear 0 10) g

--- a/examples/Spec/TicTacToe/Move.hs
+++ b/examples/Spec/TicTacToe/Move.hs
@@ -11,8 +11,6 @@ import Apropos.HasParameterisedGenerator
 import Apropos.HasPermutationGenerator
 import Apropos.LogicalModel
 import Control.Monad (join)
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear)
 import Spec.TicTacToe.Location
 import Spec.TicTacToe.Player
 import Test.Tasty (TestTree, testGroup)
@@ -49,10 +47,10 @@ instance HasPermutationGenerator MoveProperty (Int, Int) where
 instance HasParameterisedGenerator MoveProperty (Int, Int) where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen (Int, Int)
+baseGen :: Gen' (Int, Int)
 baseGen =
-  let g = Gen.int (linear minBound maxBound)
-   in liftGenP ((,) <$> g <*> g)
+  let g = int (linear minBound maxBound)
+   in (,) <$> g <*> g
 
 movePermutationGenSelfTest :: TestTree
 movePermutationGenSelfTest =
@@ -62,3 +60,4 @@ movePermutationGenSelfTest =
         True
         (\(_ :: PermutationEdge MoveProperty (Int, Int)) -> True)
         baseGen
+

--- a/examples/Spec/TicTacToe/Move.hs
+++ b/examples/Spec/TicTacToe/Move.hs
@@ -17,6 +17,8 @@ import Spec.TicTacToe.Location
 import Spec.TicTacToe.Player
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
+import Control.Lens.Tuple(_1,_2)
+
 
 data MoveProperty
   = MoveLocation LocationProperty
@@ -34,23 +36,15 @@ instance HasLogicalModel MoveProperty (Int, Int) where
 
 instance HasPermutationGenerator MoveProperty (Int, Int) where
   generators =
-    let l = ModelAbstraction { abstractionName = "MovePlayer"
-                             , projectProperty =  \p -> case p of
-                                                          (MovePlayer q) -> Just q
-                                                          _ -> Nothing
-                             , injectProperty = MovePlayer
-                             , projectSubmodel = fst
-                             , injectSubmodel = \f (_, r') -> (f, r')
+    let l = Abstraction { abstractionName = "MovePlayer"
+                        , propertyAbstraction = abstractsProperties MovePlayer
+                        , modelAbstraction = _1
+                        }
+        r = Abstraction { abstractionName = "MoveLocation"
+                        , propertyAbstraction = abstractsProperties MoveLocation
+                        , modelAbstraction = _2
                              }
-        r = ModelAbstraction { abstractionName = "MoveLocation"
-                             , projectProperty =  \p -> case p of
-                                                          (MoveLocation q) -> Just q
-                                                          _ -> Nothing
-                             , injectProperty = MoveLocation
-                             , projectSubmodel = snd
-                             , injectSubmodel = \f (l', _) -> (l', f)
-                             }
-     in join [l <$$> generators, r <$$> generators]
+     in join [abstract l <$> generators, abstract r <$> generators]
 
 instance HasParameterisedGenerator MoveProperty (Int, Int) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/TicTacToe/Move.hs
+++ b/examples/Spec/TicTacToe/Move.hs
@@ -58,6 +58,6 @@ movePermutationGenSelfTest =
     fromGroup
       <$> permutationGeneratorSelfTest
         True
-        (\(_ :: PermutationEdge MoveProperty (Int, Int)) -> True)
+        (\(_ :: Morphism MoveProperty (Int, Int)) -> True)
         baseGen
 

--- a/examples/Spec/TicTacToe/Move.hs
+++ b/examples/Spec/TicTacToe/Move.hs
@@ -47,7 +47,7 @@ instance HasPermutationGenerator MoveProperty (Int, Int) where
 instance HasParameterisedGenerator MoveProperty (Int, Int) where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: Gen' (Int, Int)
+baseGen :: Gen (Int, Int)
 baseGen =
   let g = int (linear minBound maxBound)
    in (,) <$> g <*> g

--- a/examples/Spec/TicTacToe/Move.hs
+++ b/examples/Spec/TicTacToe/Move.hs
@@ -34,29 +34,23 @@ instance HasLogicalModel MoveProperty (Int, Int) where
 
 instance HasPermutationGenerator MoveProperty (Int, Int) where
   generators =
-    let l =
-          liftEdges
-            MovePlayer
-            fst
-            (\f (_, r') -> (f, r'))
-            ( \p -> case p of
-                (MovePlayer q) -> Just q
-                _ -> Nothing
-            )
-            "MovePlayer "
-            generators
-        r =
-          liftEdges
-            MoveLocation
-            snd
-            (\f (l', _) -> (l', f))
-            ( \p -> case p of
-                (MoveLocation q) -> Just q
-                _ -> Nothing
-            )
-            "MoveLocation "
-            generators
-     in join [l, r]
+    let l = ModelAbstraction { abstractionName = "MovePlayer"
+                             , projectProperty =  \p -> case p of
+                                                          (MovePlayer q) -> Just q
+                                                          _ -> Nothing
+                             , injectProperty = MovePlayer
+                             , projectSubmodel = fst
+                             , injectSubmodel = \f (_, r') -> (f, r')
+                             }
+        r = ModelAbstraction { abstractionName = "MoveLocation"
+                             , projectProperty =  \p -> case p of
+                                                          (MoveLocation q) -> Just q
+                                                          _ -> Nothing
+                             , injectProperty = MoveLocation
+                             , projectSubmodel = snd
+                             , injectSubmodel = \f (l', _) -> (l', f)
+                             }
+     in join [l <$$> generators, r <$$> generators]
 
 instance HasParameterisedGenerator MoveProperty (Int, Int) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/TicTacToe/MoveSequence.hs
+++ b/examples/Spec/TicTacToe/MoveSequence.hs
@@ -62,8 +62,8 @@ instance HasLogicalModel MoveSequenceProperty [Int] where
   satisfiesProperty MoveSequenceValid ms = satisfiesExpression locationSequenceIsValid ms
   satisfiesProperty MoveSequenceContainsWin ms = containsWin ms
 
-baseGen :: Gen' [Int]
-baseGen = liftGen $ genSatisfying (Yes :: Formula LocationSequenceProperty)
+baseGen :: Gen [Int]
+baseGen = genSatisfying (Yes :: Formula LocationSequenceProperty)
 
 instance HasPermutationGenerator MoveSequenceProperty [Int] where
   generators =
@@ -71,24 +71,21 @@ instance HasPermutationGenerator MoveSequenceProperty [Int] where
         { name = "InvalidNoWin"
         , match = Yes
         , contract = clear
-        , morphism = do
-            genFilter (not . containsWin) $ liftGen
-               $ genSatisfying $ Not locationSequenceIsValid
+        , morphism = \_ -> genFilter (not . containsWin) 
+                             $ genSatisfying $ Not locationSequenceIsValid
         }
     , Morphism
         { name = "ValidNoWin"
         , match = Yes
         , contract = clear >> add MoveSequenceValid
-        , morphism = do
-           genFilter (not . containsWin) $ liftGen
-               $ genSatisfying locationSequenceIsValid
+        , morphism = \_ -> genFilter (not . containsWin)
+                             $ genSatisfying locationSequenceIsValid
         }
     , Morphism
         { name = "InvalidWin"
         , match = Not $ Var MoveSequenceValid
         , contract = add MoveSequenceContainsWin
-        , morphism = do
-            moves <- source
+        , morphism = \moves -> do
             winlocs <- Set.toList <$> (element winTileSets)
             whofirst <- element [[moves, winlocs], [winlocs, moves]]
             let win = join $ transpose whofirst
@@ -100,8 +97,7 @@ instance HasPermutationGenerator MoveSequenceProperty [Int] where
         { name = "ValidWin"
         , match = Var MoveSequenceValid
         , contract = add MoveSequenceContainsWin
-        , morphism = do
-            moves <- source
+        , morphism = \moves -> do
             winlocs <- Set.toList <$> (element winTileSets)
             whofirst <- element [[moves, winlocs], [winlocs, moves]]
             let win = join $ transpose whofirst

--- a/examples/Spec/TicTacToe/MoveSequence.hs
+++ b/examples/Spec/TicTacToe/MoveSequence.hs
@@ -67,27 +67,27 @@ baseGen = liftGen $ genSatisfying (Yes :: Formula LocationSequenceProperty)
 
 instance HasPermutationGenerator MoveSequenceProperty [Int] where
   generators =
-    [ PermutationEdge
+    [ Morphism
         { name = "InvalidNoWin"
         , match = Yes
         , contract = clear
-        , permuteGen = do
+        , morphism = do
             genFilter (not . containsWin) $ liftGen
                $ genSatisfying $ Not locationSequenceIsValid
         }
-    , PermutationEdge
+    , Morphism
         { name = "ValidNoWin"
         , match = Yes
         , contract = clear >> add MoveSequenceValid
-        , permuteGen = do
+        , morphism = do
            genFilter (not . containsWin) $ liftGen
                $ genSatisfying locationSequenceIsValid
         }
-    , PermutationEdge
+    , Morphism
         { name = "InvalidWin"
         , match = Not $ Var MoveSequenceValid
         , contract = add MoveSequenceContainsWin
-        , permuteGen = do
+        , morphism = do
             moves <- source
             winlocs <- Set.toList <$> (element winTileSets)
             whofirst <- element [[moves, winlocs], [winlocs, moves]]
@@ -96,11 +96,11 @@ instance HasPermutationGenerator MoveSequenceProperty [Int] where
               then pure win
               else retry
         }
-    , PermutationEdge
+    , Morphism
         { name = "ValidWin"
         , match = Var MoveSequenceValid
         , contract = add MoveSequenceContainsWin
-        , permuteGen = do
+        , morphism = do
             moves <- source
             winlocs <- Set.toList <$> (element winTileSets)
             whofirst <- element [[moves, winlocs], [winlocs, moves]]
@@ -120,5 +120,5 @@ moveSequencePermutationGenSelfTest =
     fromGroup
       <$> permutationGeneratorSelfTest
         True
-        (\(_ :: PermutationEdge MoveSequenceProperty [Int]) -> True)
+        (\(_ :: Morphism MoveSequenceProperty [Int]) -> True)
         baseGen

--- a/examples/Spec/TicTacToe/Player.hs
+++ b/examples/Spec/TicTacToe/Player.hs
@@ -9,8 +9,6 @@ import Apropos.HasParameterisedGenerator
 import Apropos.HasPermutationGenerator
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.LogicalModel
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -52,20 +50,16 @@ instance HasPermutationGenerator PlayerProperty Int where
         { name = "MakePlayerInvalid"
         , match = Not $ Var PlayerIsInvalid
         , contract = removeAll [PlayerIsX, PlayerIsO] >> add PlayerIsInvalid
-        , permuteGen = do
-            p <-
-              liftGenPA $
-                Gen.filter (\i -> not (i `elem` [0, 1])) $
-                  Gen.int (linear minBound maxBound)
-            pure p
+        , permuteGen = genFilter (\i -> not (i `elem` [0, 1])) $
+                  int (linear minBound maxBound)
         }
     ]
 
 instance HasParameterisedGenerator PlayerProperty Int where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen Int
-baseGen = liftGenP $ Gen.int (linear minBound maxBound)
+baseGen :: Gen' Int
+baseGen = int (linear minBound maxBound)
 
 playerPermutationGenSelfTest :: TestTree
 playerPermutationGenSelfTest =

--- a/examples/Spec/TicTacToe/Player.hs
+++ b/examples/Spec/TicTacToe/Player.hs
@@ -36,29 +36,27 @@ instance HasPermutationGenerator PlayerProperty Int where
         { name = "MakePlayerX"
         , match = Not $ Var PlayerIsX
         , contract = removeAll [PlayerIsO, PlayerIsInvalid] >> add PlayerIsX
-        , morphism = do
-            pure 1
+        , morphism = \_ -> pure 1
         }
     , Morphism
         { name = "MakePlayerO"
         , match = Not $ Var PlayerIsO
         , contract = removeAll [PlayerIsX, PlayerIsInvalid] >> add PlayerIsO
-        , morphism = do
-            pure 0
+        , morphism = \_ -> pure 0
         }
     , Morphism
         { name = "MakePlayerInvalid"
         , match = Not $ Var PlayerIsInvalid
         , contract = removeAll [PlayerIsX, PlayerIsO] >> add PlayerIsInvalid
-        , morphism = genFilter (\i -> not (i `elem` [0, 1])) $
-                  int (linear minBound maxBound)
+        , morphism = \_ -> genFilter (\i -> not (i `elem` [0, 1]))
+                              $ int (linear minBound maxBound)
         }
     ]
 
 instance HasParameterisedGenerator PlayerProperty Int where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: Gen' Int
+baseGen :: Gen Int
 baseGen = int (linear minBound maxBound)
 
 playerPermutationGenSelfTest :: TestTree

--- a/examples/Spec/TicTacToe/Player.hs
+++ b/examples/Spec/TicTacToe/Player.hs
@@ -32,25 +32,25 @@ instance HasLogicalModel PlayerProperty Int where
 
 instance HasPermutationGenerator PlayerProperty Int where
   generators =
-    [ PermutationEdge
+    [ Morphism
         { name = "MakePlayerX"
         , match = Not $ Var PlayerIsX
         , contract = removeAll [PlayerIsO, PlayerIsInvalid] >> add PlayerIsX
-        , permuteGen = do
+        , morphism = do
             pure 1
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakePlayerO"
         , match = Not $ Var PlayerIsO
         , contract = removeAll [PlayerIsX, PlayerIsInvalid] >> add PlayerIsO
-        , permuteGen = do
+        , morphism = do
             pure 0
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakePlayerInvalid"
         , match = Not $ Var PlayerIsInvalid
         , contract = removeAll [PlayerIsX, PlayerIsO] >> add PlayerIsInvalid
-        , permuteGen = genFilter (\i -> not (i `elem` [0, 1])) $
+        , morphism = genFilter (\i -> not (i `elem` [0, 1])) $
                   int (linear minBound maxBound)
         }
     ]
@@ -67,5 +67,5 @@ playerPermutationGenSelfTest =
     fromGroup
       <$> permutationGeneratorSelfTest
         True
-        (\(_ :: PermutationEdge PlayerProperty Int) -> True)
+        (\(_ :: Morphism PlayerProperty Int) -> True)
         baseGen

--- a/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
+++ b/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
@@ -64,7 +64,7 @@ instance HasPermutationGenerator PlayerLocationSequencePairProperty ([Int], [Int
 instance HasParameterisedGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: Gen' ([Int], [Int])
+baseGen :: Gen ([Int], [Int])
 baseGen = do
   l <- int (linear 0 10)
   l1 <- list (singleton l) $ int (linear minBound maxBound)

--- a/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
+++ b/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
@@ -51,29 +51,31 @@ instance HasLogicalModel PlayerLocationSequencePairProperty ([Int], [Int]) where
 
 instance HasPermutationGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   generators =
-    let l =
-          liftEdges
-            PlayerLocationSequencePairPlayer
-            fst
-            (\f moves -> (f, snd moves))
-            ( \p -> case p of
-                (PlayerLocationSequencePairPlayer q) -> Just q
-                _ -> Nothing
-            )
-            ""
-            generators
-        r =
-          liftEdges
-            PlayerLocationSequencePairLocation
-            snd
-            (\f moves -> (fst moves, f))
-            ( \p -> case p of
-                (PlayerLocationSequencePairLocation q) -> Just q
-                _ -> Nothing
-            )
-            ""
-            generators
-     in [composeEdges l' r' | l' <- l, r' <- r]
+    let l = ModelAbstraction { abstractionName = ""
+                             , projectProperty =  \p ->
+                                 case p of
+                                   (PlayerLocationSequencePairPlayer q) -> Just q
+                                   _ -> Nothing
+                             , injectProperty = PlayerLocationSequencePairPlayer
+                             , projectSubmodel = fst
+                             , injectSubmodel = \f moves -> (f, snd moves)
+
+                             }
+        r = ModelAbstraction { abstractionName = ""
+                             , projectProperty =  \p ->
+                                 case p of
+                                   (PlayerLocationSequencePairLocation q) -> Just q
+                                   _ -> Nothing
+                             , injectProperty = PlayerLocationSequencePairLocation
+                             , projectSubmodel = snd
+                             , injectSubmodel = \f moves -> (fst moves, f)
+                             }
+     in (l <$$> generators) <*>> (r <$$> generators)
+
+--   how can we make this look like applicative where we have
+--     PairProp IntProp IntProp
+--   in pairPropAbstraction <$$> generators <**> generators
+--   ?
 
 instance HasParameterisedGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
+++ b/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
@@ -11,8 +11,6 @@ import Apropos.HasParameterisedGenerator
 import Apropos.HasPermutationGenerator
 import Apropos.LogicalModel
 import Control.Monad (join)
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear, singleton)
 import Spec.TicTacToe.LocationSequence
 import Spec.TicTacToe.PlayerSequence
 import Test.Tasty (TestTree, testGroup)
@@ -66,11 +64,11 @@ instance HasPermutationGenerator PlayerLocationSequencePairProperty ([Int], [Int
 instance HasParameterisedGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen ([Int], [Int])
+baseGen :: Gen' ([Int], [Int])
 baseGen = do
-  l <- liftGenP $ Gen.int (linear 0 10)
-  l1 <- liftGenP $ Gen.list (singleton l) $ Gen.int (linear minBound maxBound)
-  l2 <- liftGenP $ Gen.list (singleton l) $ Gen.int (linear minBound maxBound)
+  l <- int (linear 0 10)
+  l1 <- list (singleton l) $ int (linear minBound maxBound)
+  l2 <- list (singleton l) $ int (linear minBound maxBound)
   pure (l1, l2)
 
 playerLocationSequencePairPermutationGenSelfTest :: TestTree

--- a/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
+++ b/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
@@ -17,6 +17,8 @@ import Spec.TicTacToe.LocationSequence
 import Spec.TicTacToe.PlayerSequence
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
+import Control.Lens.Tuple(_1,_2)
+
 
 data PlayerLocationSequencePairProperty
   = PlayerLocationSequencePairLocation LocationSequenceProperty
@@ -51,31 +53,15 @@ instance HasLogicalModel PlayerLocationSequencePairProperty ([Int], [Int]) where
 
 instance HasPermutationGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   generators =
-    let l = ModelAbstraction { abstractionName = ""
-                             , projectProperty =  \p ->
-                                 case p of
-                                   (PlayerLocationSequencePairPlayer q) -> Just q
-                                   _ -> Nothing
-                             , injectProperty = PlayerLocationSequencePairPlayer
-                             , projectSubmodel = fst
-                             , injectSubmodel = \f moves -> (f, snd moves)
-
-                             }
-        r = ModelAbstraction { abstractionName = ""
-                             , projectProperty =  \p ->
-                                 case p of
-                                   (PlayerLocationSequencePairLocation q) -> Just q
-                                   _ -> Nothing
-                             , injectProperty = PlayerLocationSequencePairLocation
-                             , projectSubmodel = snd
-                             , injectSubmodel = \f moves -> (fst moves, f)
-                             }
-     in (l <$$> generators) <*>> (r <$$> generators)
-
---   how can we make this look like applicative where we have
---     PairProp IntProp IntProp
---   in pairPropAbstraction <$$> generators <**> generators
---   ?
+    let l = Abstraction { abstractionName = ""
+                        , propertyAbstraction = abstractsProperties PlayerLocationSequencePairPlayer
+                        , modelAbstraction = _1
+                        }
+        r = Abstraction { abstractionName = ""
+                        , propertyAbstraction = abstractsProperties PlayerLocationSequencePairLocation
+                        , modelAbstraction = _2
+                        }
+     in (abstract l <$> generators) |:-> (abstract r <$> generators)
 
 instance HasParameterisedGenerator PlayerLocationSequencePairProperty ([Int], [Int]) where
   parameterisedGenerator = buildGen baseGen

--- a/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
+++ b/examples/Spec/TicTacToe/PlayerLocationSequencePair.hs
@@ -77,5 +77,5 @@ playerLocationSequencePairPermutationGenSelfTest =
     fromGroup
       <$> permutationGeneratorSelfTest
         False
-        (\(_ :: PermutationEdge PlayerLocationSequencePairProperty ([Int], [Int])) -> True)
+        (\(_ :: Morphism PlayerLocationSequencePairProperty ([Int], [Int])) -> True)
         baseGen

--- a/examples/Spec/TicTacToe/PlayerSequence.hs
+++ b/examples/Spec/TicTacToe/PlayerSequence.hs
@@ -49,7 +49,7 @@ instance HasLogicalModel PlayerSequenceProperty [Int] where
 
 instance HasPermutationGenerator PlayerSequenceProperty [Int] where
   generators =
-    [ PermutationEdge
+    [ Morphism
         { name = "MakeTakeTurnsNotLongerThanGame"
         , match = Yes
         , contract =
@@ -60,13 +60,13 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
               , PlayerSequenceIsLongerThanGame
               ]
               >> add TakeTurns
-        , permuteGen = do
+        , morphism = do
             s <- source
             let numMoves = min 9 (max 2 (length s))
             pattern <- element [[0, 1], [1, 0]]
             pure $ take numMoves (cycle pattern)
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeTakeTurnsLongerThanGame"
         , match = Yes
         , contract =
@@ -79,48 +79,48 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
                 [ TakeTurns
                 , PlayerSequenceIsLongerThanGame
                 ]
-        , permuteGen = do
+        , morphism = do
             let numMoves = 10
             pattern <- element [[0, 1], [1, 0]]
             pure $ take numMoves (cycle pattern)
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakePlayerSequenceNull"
         , match = Yes
         , contract =
             removeAll [Don'tTakeTurns, PlayerSequenceSingleton]
               >> addAll [TakeTurns, PlayerSequenceNull]
-        , permuteGen = pure []
+        , morphism = pure []
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakePlayerSingletonDon'tTakeTurns"
         , match = Yes
         , contract =
             removeAll [TakeTurns, PlayerSequenceNull]
               >> addAll [Don'tTakeTurns, PlayerSequenceSingleton]
-        , permuteGen = do
+        , morphism = do
             list (singleton 1) $
                 choice
                   [ int (linear minBound (-1))
                   , int (linear 2 maxBound)
                   ]
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakePlayerSingletonTakeTurns"
         , match = Yes
         , contract =
             removeAll [Don'tTakeTurns, PlayerSequenceNull]
               >> addAll [TakeTurns, PlayerSequenceSingleton]
-        , permuteGen = do
+        , morphism = do
             list (singleton 1) $ int (linear 0 1)
         }
-    , PermutationEdge
+    , Morphism
         { name = "MakeDon'tTakeTurns"
         , match = Yes
         , contract =
             add Don'tTakeTurns
               >> removeAll [TakeTurns, PlayerSequenceSingleton, PlayerSequenceNull]
-        , permuteGen = do
+        , morphism = do
             s <- source
             let numMoves = max 2 (length s)
             let genFoulPlay = do
@@ -147,5 +147,5 @@ playerSequencePermutationGenSelfTest =
     fromGroup
       <$> permutationGeneratorSelfTest
         True
-        (\(_ :: PermutationEdge PlayerSequenceProperty [Int]) -> True)
+        (\(_ :: Morphism PlayerSequenceProperty [Int]) -> True)
         baseGen

--- a/examples/Spec/TicTacToe/PlayerSequence.hs
+++ b/examples/Spec/TicTacToe/PlayerSequence.hs
@@ -9,8 +9,6 @@ import Apropos.HasParameterisedGenerator
 import Apropos.HasPermutationGenerator
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.LogicalModel
-import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (linear, singleton)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (fromGroup)
 
@@ -65,7 +63,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
         , permuteGen = do
             s <- source
             let numMoves = min 9 (max 2 (length s))
-            pattern <- liftGenPA $ Gen.element [[0, 1], [1, 0]]
+            pattern <- element [[0, 1], [1, 0]]
             pure $ take numMoves (cycle pattern)
         }
     , PermutationEdge
@@ -83,7 +81,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
                 ]
         , permuteGen = do
             let numMoves = 10
-            pattern <- liftGenPA $ Gen.element [[0, 1], [1, 0]]
+            pattern <- element [[0, 1], [1, 0]]
             pure $ take numMoves (cycle pattern)
         }
     , PermutationEdge
@@ -101,11 +99,10 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
             removeAll [TakeTurns, PlayerSequenceNull]
               >> addAll [Don'tTakeTurns, PlayerSequenceSingleton]
         , permuteGen = do
-            liftGenPA $
-              Gen.list (singleton 1) $
-                Gen.choice
-                  [ Gen.int (linear minBound (-1))
-                  , Gen.int (linear 2 maxBound)
+            list (singleton 1) $
+                choice
+                  [ int (linear minBound (-1))
+                  , int (linear 2 maxBound)
                   ]
         }
     , PermutationEdge
@@ -115,7 +112,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
             removeAll [Don'tTakeTurns, PlayerSequenceNull]
               >> addAll [TakeTurns, PlayerSequenceSingleton]
         , permuteGen = do
-            liftGenPA $ Gen.list (singleton 1) $ Gen.int (linear 0 1)
+            list (singleton 1) $ int (linear 0 1)
         }
     , PermutationEdge
         { name = "MakeDon'tTakeTurns"
@@ -127,22 +124,22 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
             s <- source
             let numMoves = max 2 (length s)
             let genFoulPlay = do
-                  Gen.filter (satisfiesProperty Don'tTakeTurns) $
-                    Gen.list (singleton numMoves) $
-                      Gen.int (linear 0 1)
+                  genFilter (satisfiesProperty Don'tTakeTurns) $
+                    list (singleton numMoves) $
+                      int (linear 0 1)
                 genInvalid = do
-                  Gen.filter (satisfiesProperty Don'tTakeTurns) $
-                    Gen.list (singleton numMoves) $
-                      Gen.int (linear minBound maxBound)
-            liftGenPA $ Gen.choice [genFoulPlay, genInvalid]
+                  genFilter (satisfiesProperty Don'tTakeTurns) $
+                    list (singleton numMoves) $
+                      int (linear minBound maxBound)
+            choice [genFoulPlay, genInvalid]
         }
     ]
 
 instance HasParameterisedGenerator PlayerSequenceProperty [Int] where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: PGen [Int]
-baseGen = liftGenP $ Gen.list (linear 0 10) $ Gen.int (linear minBound maxBound)
+baseGen :: Gen' [Int]
+baseGen = list (linear 0 10) $ int (linear minBound maxBound)
 
 playerSequencePermutationGenSelfTest :: TestTree
 playerSequencePermutationGenSelfTest =

--- a/examples/Spec/TicTacToe/PlayerSequence.hs
+++ b/examples/Spec/TicTacToe/PlayerSequence.hs
@@ -60,8 +60,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
               , PlayerSequenceIsLongerThanGame
               ]
               >> add TakeTurns
-        , morphism = do
-            s <- source
+        , morphism = \s -> do
             let numMoves = min 9 (max 2 (length s))
             pattern <- element [[0, 1], [1, 0]]
             pure $ take numMoves (cycle pattern)
@@ -79,7 +78,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
                 [ TakeTurns
                 , PlayerSequenceIsLongerThanGame
                 ]
-        , morphism = do
+        , morphism = \_ -> do
             let numMoves = 10
             pattern <- element [[0, 1], [1, 0]]
             pure $ take numMoves (cycle pattern)
@@ -90,7 +89,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
         , contract =
             removeAll [Don'tTakeTurns, PlayerSequenceSingleton]
               >> addAll [TakeTurns, PlayerSequenceNull]
-        , morphism = pure []
+        , morphism = \_ -> pure []
         }
     , Morphism
         { name = "MakePlayerSingletonDon'tTakeTurns"
@@ -98,12 +97,11 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
         , contract =
             removeAll [TakeTurns, PlayerSequenceNull]
               >> addAll [Don'tTakeTurns, PlayerSequenceSingleton]
-        , morphism = do
-            list (singleton 1) $
-                choice
-                  [ int (linear minBound (-1))
-                  , int (linear 2 maxBound)
-                  ]
+        , morphism = \_ -> list (singleton 1)
+                            $ choice
+                                 [ int (linear minBound (-1))
+                                 , int (linear 2 maxBound)
+                                 ]
         }
     , Morphism
         { name = "MakePlayerSingletonTakeTurns"
@@ -111,8 +109,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
         , contract =
             removeAll [Don'tTakeTurns, PlayerSequenceNull]
               >> addAll [TakeTurns, PlayerSequenceSingleton]
-        , morphism = do
-            list (singleton 1) $ int (linear 0 1)
+        , morphism = \_ -> list (singleton 1) $ int (linear 0 1)
         }
     , Morphism
         { name = "MakeDon'tTakeTurns"
@@ -120,8 +117,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
         , contract =
             add Don'tTakeTurns
               >> removeAll [TakeTurns, PlayerSequenceSingleton, PlayerSequenceNull]
-        , morphism = do
-            s <- source
+        , morphism = \s -> do
             let numMoves = max 2 (length s)
             let genFoulPlay = do
                   genFilter (satisfiesProperty Don'tTakeTurns) $
@@ -138,7 +134,7 @@ instance HasPermutationGenerator PlayerSequenceProperty [Int] where
 instance HasParameterisedGenerator PlayerSequenceProperty [Int] where
   parameterisedGenerator = buildGen baseGen
 
-baseGen :: Gen' [Int]
+baseGen :: Gen [Int]
 baseGen = list (linear 0 10) $ int (linear minBound maxBound)
 
 playerSequencePermutationGenSelfTest :: TestTree

--- a/src/Apropos.hs
+++ b/src/Apropos.hs
@@ -46,7 +46,7 @@ module Apropos (
 
   -- Apropos.HasPermutationGenerator
   HasPermutationGenerator(..),
-  PermutationEdge(..),
+  Morphism(..),
   Abstraction(..),
   abstract,
   abstractsProperties,

--- a/src/Apropos.hs
+++ b/src/Apropos.hs
@@ -1,0 +1,93 @@
+module Apropos (
+  -- Apropos.Type
+  Apropos(..),
+  (:+),
+
+  -- Apropos.LogicalModel
+  LogicalModel(..),
+
+  -- Apropos.LogicalModel.Enumerable
+  Enumerable(..),
+  gen_enumerable,
+
+  -- Apropos.LogicalModel.Formula
+  Formula(..),
+
+  -- Apropos.HasLogicalModel
+  HasLogicalModel(..),
+
+  -- Apropos.Gen
+  Gen,
+  Gen',
+  liftGen,
+  source,
+  sink,
+  label,
+  failWithFootnote,
+  bool,
+  int,
+  list,
+  shuffle,
+  element,
+  choice,
+  genFilter,
+  retry,
+
+  -- Apropos.Gen.Range
+  Range,
+  linear,
+  singleton,
+
+  -- Apropos.HasParameterisedGenerator
+  HasParameterisedGenerator (..),
+  runGeneratorTest,
+  runGeneratorTestsWhere,
+  genSatisfying,
+
+  -- Apropos.HasPermutationGenerator
+  HasPermutationGenerator(..),
+  PermutationEdge(..),
+  Abstraction(..),
+  abstract,
+  abstractsProperties,
+  (|:->),
+
+  -- Apropos.HasPermutationGenerator.Contract
+  Contract,
+  runContract,
+  readContractInput,
+  readContractEdgeName,
+  readContractOutput,
+  writeContractOutput,
+  branches,
+  branchIf,
+  has,
+  hasn't,
+  hasAll,
+  hasNone,
+  add,
+  addIf,
+  addAll,
+  addAllIf,
+  remove,
+  removeIf,
+  removeAll,
+  removeAllIf,
+  clear,
+  output,
+  contractError,
+  terminal,
+
+  -- Apropos.Pure
+  HasPureRunner(..),
+
+  )
+  where
+import Apropos.Type
+import Apropos.LogicalModel
+import Apropos.HasLogicalModel
+import Apropos.Gen
+import Apropos.HasParameterisedGenerator
+import Apropos.HasPermutationGenerator
+import Apropos.HasPermutationGenerator.Contract
+import Apropos.Pure

--- a/src/Apropos.hs
+++ b/src/Apropos.hs
@@ -18,10 +18,6 @@ module Apropos (
 
   -- Apropos.Gen
   Gen,
-  Gen',
-  liftGen,
-  source,
-  sink,
   label,
   failWithFootnote,
   bool,

--- a/src/Apropos/Gen.hs
+++ b/src/Apropos/Gen.hs
@@ -7,6 +7,7 @@ module Apropos.Gen (
   handleRootRetries,
 
   source,
+  sink,
   label,
   failWithFootnote,
   liftEdge,
@@ -99,6 +100,10 @@ instance Functor (FreeGen m) where
 type Gen p = Free (FreeGen p)
 
 type Gen' p = Gen p p
+
+
+sink :: a -> Gen m a
+sink = pure
 
 source :: Gen m m
 source = liftF (ReadGenInput id)

--- a/src/Apropos/Gen.hs
+++ b/src/Apropos/Gen.hs
@@ -1,17 +1,12 @@
 module Apropos.Gen (
   Gen,
-  Gen',
   GenException,
   genProp,
-  genRoot,
   handleRootRetries,
+  gen,
 
-  source,
-  sink,
   label,
   failWithFootnote,
-  liftMorphism,
-  liftGen,
   bool,
   int,
   list,
@@ -26,10 +21,10 @@ module Apropos.Gen (
   linear,
   singleton,
 ) where
+import Apropos.Gen.Range
 import Control.Monad.Free
 import Control.Monad (void)
 import Control.Monad.Trans (lift)
-import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
 import Control.Monad.Trans.Except (ExceptT,throwE,runExceptT)
 import Hedgehog (PropertyT,Property)
 import qualified Hedgehog as H
@@ -37,54 +32,24 @@ import qualified Hedgehog.Gen as HGen
 import qualified Hedgehog.Range as HRange
 import Data.String (fromString)
 
-data Range = Linear Int Int | Singleton Int
+data FreeGen next where
+  Label :: String -> next -> FreeGen next
+  FailWithFootnote :: forall a next . String -> (a -> next) -> FreeGen next
+  GenBool :: (Bool -> next) -> FreeGen next
+  GenInt :: Range -> (Int -> next) -> FreeGen next
+  GenList :: forall a next .
+    Range -> (Gen a) -> ([a] -> next) -> FreeGen next
+  GenShuffle :: forall a next . Show a =>
+    [a] -> ([a] -> next) -> FreeGen next
+  GenElement :: forall a next . Show a =>
+    [a] -> (a -> next) -> FreeGen next
+  GenChoice :: forall a next .
+    [Gen a] -> (a -> next) -> FreeGen next
+  GenFilter :: forall a next . Show a =>
+    (a -> Bool) -> (Gen a) -> (a -> next) -> FreeGen next
+  RootRetry :: forall a next . (a -> next) -> FreeGen next
 
-linear :: Int -> Int -> Range
-linear a b = Linear a b
-
-singleton :: Int -> Range
-singleton s = Singleton s
-
---rangeSize :: Range -> Int
---rangeSize (Singleton _) = 1
---rangeSize (Linear lo hi) = 1 + fromIntegral (max 0 (hi - lo))
---
---rangeHi :: Range -> Int
---rangeHi (Singleton s) = fromIntegral s
---rangeHi (Linear _ hi) = fromIntegral hi
---
---rangeLo :: Range -> Int
---rangeLo (Singleton s) = fromIntegral s
---rangeLo (Linear lo _) = fromIntegral lo
-
-hRange :: Range -> H.Range Int
-hRange (Singleton s) = HRange.singleton s
-hRange (Linear lo hi) = HRange.linear lo hi
-
-data FreeGen m next where
-  ReadGenInput :: forall m next . (m -> next)  -> FreeGen m next
-  LiftMorphism :: forall m n next . Gen n n -> n -> (n -> next) -> FreeGen m next
-  LiftGen :: forall m n next . Gen n n -> (n -> next) -> FreeGen m next
-  Label :: String -> next -> FreeGen m next
-  FailWithFootnote :: forall a m next . String -> (a -> next) -> FreeGen m next
-  GenBool :: (Bool -> next) -> FreeGen m next
-  GenInt :: Range -> (Int -> next) -> FreeGen m next
-  GenList :: forall m a next .
-    Range -> (Gen m a) -> ([a] -> next) -> FreeGen m next
-  GenShuffle :: forall m a next . Show a =>
-    [a] -> ([a] -> next) -> FreeGen m next
-  GenElement :: forall m a next . Show a =>
-    [a] -> (a -> next) -> FreeGen m next
-  GenChoice :: forall m a next .
-    [Gen m a] -> (a -> next) -> FreeGen m next
-  GenFilter :: forall a m next . Show a =>
-    (a -> Bool) -> (Gen m a) -> (a -> next) -> FreeGen m next
-  RootRetry :: forall a m next . (a -> next) -> FreeGen m next
-
-instance Functor (FreeGen m) where
-  fmap f (ReadGenInput next) = ReadGenInput (f . next)
-  fmap f (LiftMorphism e i next) = LiftMorphism e i (f . next)
-  fmap f (LiftGen g next) = LiftGen g (f . next)
+instance Functor (FreeGen) where
   fmap f (Label l next) = Label l (f next)
   fmap f (FailWithFootnote l next) = FailWithFootnote l (f . next)
   fmap f (GenBool next) = GenBool (f . next)
@@ -96,59 +61,40 @@ instance Functor (FreeGen m) where
   fmap f (GenFilter c g next) = GenFilter c g (f . next)
   fmap f (RootRetry next) = RootRetry (f . next)
 
+type Gen = Free FreeGen
 
-type Gen p = Free (FreeGen p)
-
-type Gen' p = Gen p p
-
-
-sink :: a -> Gen m a
-sink = pure
-
-source :: Gen m m
-source = liftF (ReadGenInput id)
-
-liftMorphism :: Gen n n -> n -> Gen m n
-liftMorphism e i = liftF (LiftMorphism e i id)
-
-liftGen :: Gen n n -> Gen m n
-liftGen g = liftF (LiftGen g id)
-
-label :: String -> Gen m ()
+label :: String -> Gen ()
 label s = liftF (Label s ())
 
-failWithFootnote :: String -> Gen m a
+failWithFootnote :: String -> Gen a
 failWithFootnote s = liftF (FailWithFootnote s id)
 
-bool :: Gen m Bool
+bool :: Gen Bool
 bool = liftF (GenBool id)
 
-int :: Range -> Gen m Int
+int :: Range -> Gen Int
 int r = liftF (GenInt r id)
 
-list :: Range -> Gen m a -> Gen m [a]
+list :: Range -> Gen a -> Gen [a]
 list r g = liftF (GenList r g id)
 
-shuffle :: Show a => [a] -> Gen m [a]
+shuffle :: Show a => [a] -> Gen [a]
 shuffle l = liftF (GenShuffle l id)
 
-element :: Show a => [a] -> Gen m a
+element :: Show a => [a] -> Gen a
 element l = liftF (GenElement l id)
 
-choice :: [Gen m a] -> Gen m a
+choice :: [Gen a] -> Gen a
 choice g = liftF (GenChoice g id)
 
-genFilter :: Show a => (a -> Bool) -> Gen m a -> Gen m a
+genFilter :: Show a => (a -> Bool) -> Gen a -> Gen a
 genFilter c g = liftF (GenFilter c g id)
 
-retry :: Gen m a
+retry :: Gen a
 retry = liftF (RootRetry id)
 
-genProp :: Gen m a -> Property
-genProp g = H.property $ void $ runExceptT (genRoot g)
-
-genRoot :: Gen m a -> ExceptT GenException (PropertyT IO) a
-genRoot g = runReaderT (gen g) Nothing
+genProp :: Gen a -> Property
+genProp g = H.property $ void $ runExceptT $ gen g
 
 data GenException = GenException String | Retry deriving stock (Show)
 
@@ -156,59 +102,48 @@ type GenContext = PropertyT IO
 
 type Generator = ExceptT GenException GenContext
 
-type GenMorphism m a = ReaderT (Maybe m) Generator a
-
-gen :: forall m a . Gen m a -> GenMorphism m a
-gen (Free (ReadGenInput next)) = do
-  m <- ask
-  case m of
-    Nothing -> lift $ throwE $ GenException "can't read input in root gen"
-    Just so -> gen $ next so
-gen (Free (LiftMorphism e i next)) = lift (genMorphism e i) >>>= next
-gen (Free (LiftGen g next)) = lift (genRoot g) >>>= next
+gen :: Gen a -> Generator a
 gen (Free (Label s next)) = H.label (fromString s) >> gen next
 gen (Free (FailWithFootnote s _)) = H.footnote s >> H.failure
-gen (Free (GenBool next)) = (lift $ lift $ H.forAll $ HGen.bool) >>= (gen . next)
+gen (Free (GenBool next)) = (lift $ H.forAll $ HGen.bool) >>= (gen . next)
 gen (Free (GenInt r next)) = do
-  i <- lift $ lift (H.forAll $ HGen.int (hRange r))
+  i <- lift (H.forAll $ HGen.int (hRange r))
   gen $ next i
 gen (Free (GenList r g next)) = do
   let gs = int r >>= \l -> sequence $ replicate l g
   gen gs >>>= next
 gen (Free (GenShuffle ls next)) = do
-  s <- lift $ lift $ H.forAll $ HGen.shuffle ls
+  s <- lift $ H.forAll $ HGen.shuffle ls
   gen $ next s
 gen (Free (GenElement ls next)) = do
-  s <- lift $ lift $ H.forAll $ HGen.element ls
+  s <- lift $ H.forAll $ HGen.element ls
   gen $ next s
 gen (Free (GenChoice gs next)) = do
   let l = length gs
   if l == 0
-     then lift $ throwE $ GenException "GenChoice: list length zero"
+     then throwE $ GenException "GenChoice: list length zero"
      else do
-       i <- lift $ lift (H.forAll $ HGen.int (HRange.linear 0 (l-1)))
+       i <- lift (H.forAll $ HGen.int (HRange.linear 0 (l-1)))
        (gs!!i) >>== next
 gen (Free (GenFilter c g next)) = do
   genFilter' c g >>>= next
-gen (Free (RootRetry _)) = lift $ throwE Retry
+gen (Free (RootRetry _)) = throwE Retry
 gen (Pure a) = pure a
 
 
-(>>==) :: Gen m r -> (r -> Gen m a) -> GenMorphism m a
+(>>==) :: Gen r -> (r -> Gen a) -> Generator a
 (>>==) a b = do
-  m <- ask
-  r <- lift $ lift (runExceptT (runReaderT (gen a) m))
+  r <- lift (runExceptT (gen a))
   case r of
     Right x -> gen $ b x
-    Left e -> lift $ throwE e
+    Left e -> throwE e
 
-(>>>=) :: GenMorphism m r -> (r -> Gen m a) -> GenMorphism m a
+(>>>=) :: Generator r -> (r -> Gen a) -> Generator a
 (>>>=) a b = do
-  m <- ask
-  r <- lift $ lift (runExceptT (runReaderT a m))
+  r <- lift (runExceptT a)
   case r of
     Right x -> gen $ b x
-    Left e -> lift $ throwE e
+    Left e -> throwE e
 
 handleRootRetries :: Int -> Generator a -> GenContext a
 handleRootRetries 0 _ = H.footnote ("global retry limit reached reached") >> H.failure
@@ -219,19 +154,21 @@ handleRootRetries l g = do
     Left Retry -> handleRootRetries (l-1) g
     Left (GenException e) -> H.footnote e >> H.failure
 
-genMorphism :: Gen m a -> m -> Generator a
-genMorphism g m = runReaderT (gen g) (Just m)
-
-genFilter' :: forall m r. (r -> Bool) -> Gen m r -> GenMorphism m r
+genFilter' :: forall r . (r -> Bool) -> Gen r -> Generator r
 genFilter' condition g = go 100
   where
-    go :: Int -> GenMorphism m r
+    go :: Int -> Generator r
     go l = do
       if l < 0
-        then lift $ throwE Retry
+        then throwE Retry
         else do
           res <- gen g
           if condition res
             then pure res
             else go (l -1)
+
+hRange :: Range -> H.Range Int
+hRange (Singleton s) = HRange.singleton s
+hRange (Linear lo hi) = HRange.linear lo hi
+
 

--- a/src/Apropos/Gen.hs
+++ b/src/Apropos/Gen.hs
@@ -10,7 +10,7 @@ module Apropos.Gen (
   sink,
   label,
   failWithFootnote,
-  liftEdge,
+  liftMorphism,
   liftGen,
   bool,
   int,
@@ -63,7 +63,7 @@ hRange (Linear lo hi) = HRange.linear lo hi
 
 data FreeGen m next where
   ReadGenInput :: forall m next . (m -> next)  -> FreeGen m next
-  LiftEdge :: forall m n next . Gen n n -> n -> (n -> next) -> FreeGen m next
+  LiftMorphism :: forall m n next . Gen n n -> n -> (n -> next) -> FreeGen m next
   LiftGen :: forall m n next . Gen n n -> (n -> next) -> FreeGen m next
   Label :: String -> next -> FreeGen m next
   FailWithFootnote :: forall a m next . String -> (a -> next) -> FreeGen m next
@@ -83,7 +83,7 @@ data FreeGen m next where
 
 instance Functor (FreeGen m) where
   fmap f (ReadGenInput next) = ReadGenInput (f . next)
-  fmap f (LiftEdge e i next) = LiftEdge e i (f . next)
+  fmap f (LiftMorphism e i next) = LiftMorphism e i (f . next)
   fmap f (LiftGen g next) = LiftGen g (f . next)
   fmap f (Label l next) = Label l (f next)
   fmap f (FailWithFootnote l next) = FailWithFootnote l (f . next)
@@ -108,8 +108,8 @@ sink = pure
 source :: Gen m m
 source = liftF (ReadGenInput id)
 
-liftEdge :: Gen n n -> n -> Gen m n
-liftEdge e i = liftF (LiftEdge e i id)
+liftMorphism :: Gen n n -> n -> Gen m n
+liftMorphism e i = liftF (LiftMorphism e i id)
 
 liftGen :: Gen n n -> Gen m n
 liftGen g = liftF (LiftGen g id)
@@ -164,7 +164,7 @@ gen (Free (ReadGenInput next)) = do
   case m of
     Nothing -> lift $ throwE $ GenException "can't read input in root gen"
     Just so -> gen $ next so
-gen (Free (LiftEdge e i next)) = lift (genEdge e i) >>>= next
+gen (Free (LiftMorphism e i next)) = lift (genMorphism e i) >>>= next
 gen (Free (LiftGen g next)) = lift (genRoot g) >>>= next
 gen (Free (Label s next)) = H.label (fromString s) >> gen next
 gen (Free (FailWithFootnote s _)) = H.footnote s >> H.failure
@@ -219,8 +219,8 @@ handleRootRetries l g = do
     Left Retry -> handleRootRetries (l-1) g
     Left (GenException e) -> H.footnote e >> H.failure
 
-genEdge :: Gen m a -> m -> Generator a
-genEdge g m = runReaderT (gen g) (Just m)
+genMorphism :: Gen m a -> m -> Generator a
+genMorphism g m = runReaderT (gen g) (Just m)
 
 genFilter' :: forall m r. (r -> Bool) -> Gen m r -> GenMorphism m r
 genFilter' condition g = go 100

--- a/src/Apropos/Gen.hs
+++ b/src/Apropos/Gen.hs
@@ -1,54 +1,232 @@
 module Apropos.Gen (
-  PAGen,
-  PGen,
-  source,
-  runGenPA,
-  liftGenPA,
-  liftGenP,
-  list,
-  listPA,
-  filterPA,
-) where
+  Gen,
+  Gen',
+  GenException,
+  genProp,
+  genRoot,
+  handleRootRetries,
 
+  source,
+  label,
+  failWithFootnote,
+  liftEdge,
+  liftGen,
+  bool,
+  int,
+  list,
+  shuffle,
+  element,
+  choice,
+
+  genFilter,
+  retry,
+
+  Range,
+  linear,
+  singleton,
+) where
+import Control.Monad.Free
+import Control.Monad (void)
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
-import Hedgehog (Gen, PropertyT, Range, forAll)
-import qualified Hedgehog.Gen as Gen
+import Control.Monad.Trans.Except (ExceptT,throwE,runExceptT)
+import Hedgehog (PropertyT,Property)
+import qualified Hedgehog as H
+import qualified Hedgehog.Gen as HGen
+import qualified Hedgehog.Range as HRange
+import Data.String (fromString)
 
-type PAGen m r = ReaderT m (PropertyT IO) r
-type PGen r = PropertyT IO r
+data Range = Linear Int Int | Singleton Int
 
-source :: PAGen m m
-source = ask
+linear :: Int -> Int -> Range
+linear a b = Linear a b
 
-runGenPA :: forall m r. PAGen m r -> m -> PGen r
-runGenPA g m = runReaderT g m
+singleton :: Int -> Range
+singleton s = Singleton s
 
-liftGenPA :: Show r => Gen r -> PAGen m r
-liftGenPA = lift . forAll
+--rangeSize :: Range -> Int
+--rangeSize (Singleton _) = 1
+--rangeSize (Linear lo hi) = 1 + fromIntegral (max 0 (hi - lo))
+--
+--rangeHi :: Range -> Int
+--rangeHi (Singleton s) = fromIntegral s
+--rangeHi (Linear _ hi) = fromIntegral hi
+--
+--rangeLo :: Range -> Int
+--rangeLo (Singleton s) = fromIntegral s
+--rangeLo (Linear lo _) = fromIntegral lo
 
-liftGenP :: Show r => Gen r -> PGen r
-liftGenP = forAll
+hRange :: Range -> H.Range Int
+hRange (Singleton s) = HRange.singleton s
+hRange (Linear lo hi) = HRange.linear lo hi
 
-list :: Range Int -> PGen r -> PAGen m [r]
-list range gen = do
-  l <- liftGenPA $ Gen.int range
-  sequence $ replicate l (lift gen)
+data FreeGen m next where
+  ReadGenInput :: forall m next . (m -> next)  -> FreeGen m next
+  LiftEdge :: forall m n next . Gen n n -> n -> (n -> next) -> FreeGen m next
+  LiftGen :: forall m n next . Gen n n -> (n -> next) -> FreeGen m next
+  Label :: String -> next -> FreeGen m next
+  FailWithFootnote :: forall a m next . String -> (a -> next) -> FreeGen m next
+  GenBool :: (Bool -> next) -> FreeGen m next
+  GenInt :: Range -> (Int -> next) -> FreeGen m next
+  GenList :: forall m a next .
+    Range -> (Gen m a) -> ([a] -> next) -> FreeGen m next
+  GenShuffle :: forall m a next . Show a =>
+    [a] -> ([a] -> next) -> FreeGen m next
+  GenElement :: forall m a next . Show a =>
+    [a] -> (a -> next) -> FreeGen m next
+  GenChoice :: forall m a next .
+    [Gen m a] -> (a -> next) -> FreeGen m next
+  GenFilter :: forall a m next . Show a =>
+    (a -> Bool) -> (Gen m a) -> (a -> next) -> FreeGen m next
+  RootRetry :: forall a m next . (a -> next) -> FreeGen m next
 
-listPA :: Range Int -> PAGen m r -> PAGen m [r]
-listPA range gen = do
-  l <- liftGenPA $ Gen.int range
-  sequence $ replicate l gen
+instance Functor (FreeGen m) where
+  fmap f (ReadGenInput next) = ReadGenInput (f . next)
+  fmap f (LiftEdge e i next) = LiftEdge e i (f . next)
+  fmap f (LiftGen g next) = LiftGen g (f . next)
+  fmap f (Label l next) = Label l (f next)
+  fmap f (FailWithFootnote l next) = FailWithFootnote l (f . next)
+  fmap f (GenBool next) = GenBool (f . next)
+  fmap f (GenInt r next) = GenInt r (f . next)
+  fmap f (GenList r g next) = GenList r g (f . next)
+  fmap f (GenShuffle l next) = GenShuffle l (f . next)
+  fmap f (GenElement ls next) = GenElement ls (f . next)
+  fmap f (GenChoice gs next) = GenChoice gs (f . next)
+  fmap f (GenFilter c g next) = GenFilter c g (f . next)
+  fmap f (RootRetry next) = RootRetry (f . next)
 
-filterPA :: forall m r. (r -> Bool) -> PAGen m r -> PAGen m r
-filterPA condition g = go 100
+
+type Gen p = Free (FreeGen p)
+
+type Gen' p = Gen p p
+
+source :: Gen m m
+source = liftF (ReadGenInput id)
+
+liftEdge :: Gen n n -> n -> Gen m n
+liftEdge e i = liftF (LiftEdge e i id)
+
+liftGen :: Gen n n -> Gen m n
+liftGen g = liftF (LiftGen g id)
+
+label :: String -> Gen m ()
+label s = liftF (Label s ())
+
+failWithFootnote :: String -> Gen m a
+failWithFootnote s = liftF (FailWithFootnote s id)
+
+bool :: Gen m Bool
+bool = liftF (GenBool id)
+
+int :: Range -> Gen m Int
+int r = liftF (GenInt r id)
+
+list :: Range -> Gen m a -> Gen m [a]
+list r g = liftF (GenList r g id)
+
+shuffle :: Show a => [a] -> Gen m [a]
+shuffle l = liftF (GenShuffle l id)
+
+element :: Show a => [a] -> Gen m a
+element l = liftF (GenElement l id)
+
+choice :: [Gen m a] -> Gen m a
+choice g = liftF (GenChoice g id)
+
+genFilter :: Show a => (a -> Bool) -> Gen m a -> Gen m a
+genFilter c g = liftF (GenFilter c g id)
+
+retry :: Gen m a
+retry = liftF (RootRetry id)
+
+genProp :: Gen m a -> Property
+genProp g = H.property $ void $ runExceptT (genRoot g)
+
+genRoot :: Gen m a -> ExceptT GenException (PropertyT IO) a
+genRoot g = runReaderT (gen g) Nothing
+
+data GenException = GenException String | Retry deriving stock (Show)
+
+type GenContext = PropertyT IO
+
+type Generator = ExceptT GenException GenContext
+
+type GenMorphism m a = ReaderT (Maybe m) Generator a
+
+gen :: forall m a . Gen m a -> GenMorphism m a
+gen (Free (ReadGenInput next)) = do
+  m <- ask
+  case m of
+    Nothing -> lift $ throwE $ GenException "can't read input in root gen"
+    Just so -> gen $ next so
+gen (Free (LiftEdge e i next)) = lift (genEdge e i) >>>= next
+gen (Free (LiftGen g next)) = lift (genRoot g) >>>= next
+gen (Free (Label s next)) = H.label (fromString s) >> gen next
+gen (Free (FailWithFootnote s _)) = H.footnote s >> H.failure
+gen (Free (GenBool next)) = (lift $ lift $ H.forAll $ HGen.bool) >>= (gen . next)
+gen (Free (GenInt r next)) = do
+  i <- lift $ lift (H.forAll $ HGen.int (hRange r))
+  gen $ next i
+gen (Free (GenList r g next)) = do
+  let gs = int r >>= \l -> sequence $ replicate l g
+  gen gs >>>= next
+gen (Free (GenShuffle ls next)) = do
+  s <- lift $ lift $ H.forAll $ HGen.shuffle ls
+  gen $ next s
+gen (Free (GenElement ls next)) = do
+  s <- lift $ lift $ H.forAll $ HGen.element ls
+  gen $ next s
+gen (Free (GenChoice gs next)) = do
+  let l = length gs
+  if l == 0
+     then lift $ throwE $ GenException "GenChoice: list length zero"
+     else do
+       i <- lift $ lift (H.forAll $ HGen.int (HRange.linear 0 (l-1)))
+       (gs!!i) >>== next
+gen (Free (GenFilter c g next)) = do
+  genFilter' c g >>>= next
+gen (Free (RootRetry _)) = lift $ throwE Retry
+gen (Pure a) = pure a
+
+
+(>>==) :: Gen m r -> (r -> Gen m a) -> GenMorphism m a
+(>>==) a b = do
+  m <- ask
+  r <- lift $ lift (runExceptT (runReaderT (gen a) m))
+  case r of
+    Right x -> gen $ b x
+    Left e -> lift $ throwE e
+
+(>>>=) :: GenMorphism m r -> (r -> Gen m a) -> GenMorphism m a
+(>>>=) a b = do
+  m <- ask
+  r <- lift $ lift (runExceptT (runReaderT a m))
+  case r of
+    Right x -> gen $ b x
+    Left e -> lift $ throwE e
+
+handleRootRetries :: Int -> Generator a -> GenContext a
+handleRootRetries 0 _ = H.footnote ("global retry limit reached reached") >> H.failure
+handleRootRetries l g = do
+  gr <- runExceptT g
+  case gr of
+    Right a -> pure a
+    Left Retry -> handleRootRetries (l-1) g
+    Left (GenException e) -> H.footnote e >> H.failure
+
+genEdge :: Gen m a -> m -> Generator a
+genEdge g m = runReaderT (gen g) (Just m)
+
+genFilter' :: forall m r. (r -> Bool) -> Gen m r -> GenMorphism m r
+genFilter' condition g = go 100
   where
-    go :: Int -> PAGen m r
-    go limit = do
-      if limit < 0
-        then error "filterPA: Tried 100 samples and rejected them all."
-        else pure ()
-      res <- g
-      if condition res
-        then pure res
-        else go (limit -1)
+    go :: Int -> GenMorphism m r
+    go l = do
+      if l < 0
+        then lift $ throwE Retry
+        else do
+          res <- gen g
+          if condition res
+            then pure res
+            else go (l -1)
+

--- a/src/Apropos/Gen/Cardinality.hs
+++ b/src/Apropos/Gen/Cardinality.hs
@@ -1,0 +1,20 @@
+module Apropos.Gen.Cardinality (
+  Cardinality(..),
+  HasCardinality(..),
+  genCardinality,
+  ) where
+import Apropos.Gen
+--import Control.Monad.Free
+
+data Cardinality =
+    Contiguous Range
+  | Product [Cardinality]
+  | Sum [Cardinality]
+
+class HasCardinality t where
+  cardinality :: t -> Cardinality
+  cardinality _ = Contiguous (singleton 1)
+
+
+genCardinality :: Gen a -> Cardinality
+genCardinality _ = undefined

--- a/src/Apropos/Gen/Range.hs
+++ b/src/Apropos/Gen/Range.hs
@@ -1,0 +1,30 @@
+module Apropos.Gen.Range (
+  Range(..),
+  linear,
+  singleton,
+  rangeSize,
+  rangeHi,
+  rangeLo,
+  ) where
+
+data Range = Linear Int Int | Singleton Int
+
+linear :: Int -> Int -> Range
+linear a b = Linear a b
+
+singleton :: Int -> Range
+singleton s = Singleton s
+
+rangeSize :: Range -> Int
+rangeSize (Singleton _) = 1
+rangeSize (Linear lo hi) = 1 + fromIntegral (max 0 (hi - lo))
+
+rangeHi :: Range -> Int
+rangeHi (Singleton s) = fromIntegral s
+rangeHi (Linear _ hi) = fromIntegral hi
+
+rangeLo :: Range -> Int
+rangeLo (Singleton s) = fromIntegral s
+rangeLo (Linear lo _) = fromIntegral lo
+
+

--- a/src/Apropos/HasParameterisedGenerator.hs
+++ b/src/Apropos/HasParameterisedGenerator.hs
@@ -1,5 +1,8 @@
 module Apropos.HasParameterisedGenerator (
   HasParameterisedGenerator (..),
+  runGeneratorTest,
+  runGeneratorTestsWhere,
+  genSatisfying,
 ) where
 
 import Apropos.Gen
@@ -9,25 +12,35 @@ import Data.Proxy (Proxy)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.String (fromString)
-import Hedgehog (Group (..), Property, forAll, label, property, (===))
-import qualified Hedgehog.Gen as Gen
+import Hedgehog (Group (..), Property, property, (===))
+import Data.Proxy (Proxy (..))
 
 class (HasLogicalModel p m, Show m) => HasParameterisedGenerator p m where
-  parameterisedGenerator :: Set p -> PGen m
+  parameterisedGenerator :: Set p -> Gen m m
+  rootRetryLimit :: Proxy (m,p) -> Int
+  rootRetryLimit _ = 100
 
-  --TODO caching calls to the solver in genSatisfying would probably be worth it
-  genSatisfying :: Formula p -> PGen m
-  genSatisfying f = do
-    label $ fromString $ show f
-    s <- forAll $ Gen.element (enumerateScenariosWhere f)
-    parameterisedGenerator s
-  runGeneratorTest :: Proxy m -> Set p -> Property
-  runGeneratorTest _ s = property $ do
-    (m :: m) <- parameterisedGenerator s
-    properties m === s
-  runGeneratorTestsWhere :: Proxy m -> String -> Formula p -> Group
-  runGeneratorTestsWhere proxy name condition =
-    Group (fromString name) $
-      [ (fromString $ show $ Set.toList scenario, runGeneratorTest proxy scenario)
-      | scenario <- enumerateScenariosWhere condition
-      ]
+--TODO caching calls to the solver in genSatisfying would probably be worth it
+runGeneratorTest :: forall p m . HasParameterisedGenerator p m
+                 => Proxy m -> Set p -> Property
+runGeneratorTest _ s = property $ do
+  (m :: m) <- handleRootRetries numRetries $ genRoot $ parameterisedGenerator s
+  properties m === s
+    where
+      numRetries :: Int
+      numRetries = rootRetryLimit (Proxy :: Proxy (m,p))
+
+runGeneratorTestsWhere :: HasParameterisedGenerator p m
+                       => Proxy m -> String -> Formula p -> Group
+runGeneratorTestsWhere proxy name condition =
+  Group (fromString name) $
+    [ (fromString $ show $ Set.toList scenario, runGeneratorTest proxy scenario)
+    | scenario <- enumerateScenariosWhere condition
+    ]
+
+genSatisfying :: HasParameterisedGenerator p m => Formula p -> Gen' m
+genSatisfying f = do
+  label $ fromString $ show f
+  s <- element (enumerateScenariosWhere f)
+  liftGen $ parameterisedGenerator s
+

--- a/src/Apropos/HasParameterisedGenerator.hs
+++ b/src/Apropos/HasParameterisedGenerator.hs
@@ -4,34 +4,32 @@ module Apropos.HasParameterisedGenerator (
   runGeneratorTestsWhere,
   genSatisfying,
 ) where
-
+import Apropos.Type
 import Apropos.Gen
 import Apropos.HasLogicalModel
 import Apropos.LogicalModel
-import Data.Proxy (Proxy)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.String (fromString)
 import Hedgehog (Group (..), Property, property, (===))
-import Data.Proxy (Proxy (..))
 
 class (HasLogicalModel p m, Show m) => HasParameterisedGenerator p m where
   parameterisedGenerator :: Set p -> Gen m m
-  rootRetryLimit :: Proxy (m,p) -> Int
+  rootRetryLimit :: m :+ p -> Int
   rootRetryLimit _ = 100
 
 --TODO caching calls to the solver in genSatisfying would probably be worth it
 runGeneratorTest :: forall p m . HasParameterisedGenerator p m
-                 => Proxy m -> Set p -> Property
+                 => m :+ p -> Set p -> Property
 runGeneratorTest _ s = property $ do
   (m :: m) <- handleRootRetries numRetries $ genRoot $ parameterisedGenerator s
   properties m === s
     where
       numRetries :: Int
-      numRetries = rootRetryLimit (Proxy :: Proxy (m,p))
+      numRetries = rootRetryLimit (Apropos :: Apropos (m,p))
 
 runGeneratorTestsWhere :: HasParameterisedGenerator p m
-                       => Proxy m -> String -> Formula p -> Group
+                       => m :+ p -> String -> Formula p -> Group
 runGeneratorTestsWhere proxy name condition =
   Group (fromString name) $
     [ (fromString $ show $ Set.toList scenario, runGeneratorTest proxy scenario)

--- a/src/Apropos/HasParameterisedGenerator.hs
+++ b/src/Apropos/HasParameterisedGenerator.hs
@@ -14,7 +14,7 @@ import Data.String (fromString)
 import Hedgehog (Group (..), Property, property, (===))
 
 class (HasLogicalModel p m, Show m) => HasParameterisedGenerator p m where
-  parameterisedGenerator :: Set p -> Gen m m
+  parameterisedGenerator :: Set p -> Gen m
   rootRetryLimit :: m :+ p -> Int
   rootRetryLimit _ = 100
 
@@ -22,7 +22,7 @@ class (HasLogicalModel p m, Show m) => HasParameterisedGenerator p m where
 runGeneratorTest :: forall p m . HasParameterisedGenerator p m
                  => m :+ p -> Set p -> Property
 runGeneratorTest _ s = property $ do
-  (m :: m) <- handleRootRetries numRetries $ genRoot $ parameterisedGenerator s
+  (m :: m) <- handleRootRetries numRetries $ gen $ parameterisedGenerator s
   properties m === s
     where
       numRetries :: Int
@@ -36,9 +36,9 @@ runGeneratorTestsWhere proxy name condition =
     | scenario <- enumerateScenariosWhere condition
     ]
 
-genSatisfying :: HasParameterisedGenerator p m => Formula p -> Gen' m
+genSatisfying :: HasParameterisedGenerator p m => Formula p -> Gen m
 genSatisfying f = do
   label $ fromString $ show f
   s <- element (enumerateScenariosWhere f)
-  liftGen $ parameterisedGenerator s
+  parameterisedGenerator s
 

--- a/src/Apropos/HasPermutationGenerator.hs
+++ b/src/Apropos/HasPermutationGenerator.hs
@@ -1,8 +1,9 @@
 module Apropos.HasPermutationGenerator (
   HasPermutationGenerator(..),
   PermutationEdge(..),
-  liftEdges,
-  composeEdges,
+  ModelAbstraction(..),
+  (<$$>),
+  (<*>>),
   ) where
 import Apropos.Gen
 import Apropos.HasLogicalModel

--- a/src/Apropos/HasPermutationGenerator.hs
+++ b/src/Apropos/HasPermutationGenerator.hs
@@ -1,15 +1,17 @@
 module Apropos.HasPermutationGenerator (
   HasPermutationGenerator(..),
   PermutationEdge(..),
-  ModelAbstraction(..),
-  (<$$>),
-  (<*>>),
+  Abstraction(..),
+  abstract,
+  abstractsProperties,
+  (|:->),
   ) where
 import Apropos.Gen
 import Apropos.HasLogicalModel
 import Apropos.LogicalModel
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.HasPermutationGenerator.PermutationEdge
+import Apropos.HasPermutationGenerator.Abstraction
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Hedgehog (Gen,PropertyT,MonadTest,Group(..),forAll,failure,footnote,property,label)

--- a/src/Apropos/HasPermutationGenerator/Abstraction.hs
+++ b/src/Apropos/HasPermutationGenerator/Abstraction.hs
@@ -7,7 +7,6 @@ module Apropos.HasPermutationGenerator.Abstraction (
 import Apropos.LogicalModel.Enumerable
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.HasPermutationGenerator.Morphism
-import Apropos.Gen
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Either (rights)
@@ -29,10 +28,9 @@ abstract abstraction edge =
   , match = ((propertyAbstraction abstraction) #) <$> match edge
   , contract = abstractContract (abstractionName abstraction)
                                 (propertyAbstraction abstraction) $ contract edge
-  , morphism = do
-        m <- source
+  , morphism = \m -> do
         let n = m ^. (modelAbstraction abstraction)
-        nn <- liftMorphism (morphism edge) n
+        nn <- (morphism edge) n
         pure $ (modelAbstraction abstraction) .~ nn $ m
   }
 

--- a/src/Apropos/HasPermutationGenerator/Abstraction.hs
+++ b/src/Apropos/HasPermutationGenerator/Abstraction.hs
@@ -13,8 +13,6 @@ import Apropos.Gen
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Either (rights)
-import Control.Monad.Trans (lift)
-import Control.Monad.Trans.Reader (ask) --TODO refactor gen monad abstraction
 import Control.Lens
 
 data Abstraction ap am bp bm =
@@ -34,9 +32,9 @@ abstract abstraction edge =
   , contract = abstractContract (abstractionName abstraction)
                                 (propertyAbstraction abstraction) $ contract edge
   , permuteGen = do
-        m <- ask
+        m <- source
         let n = m ^. (modelAbstraction abstraction)
-        nn <- lift $ runGenPA (permuteGen edge) n
+        nn <- liftEdge (permuteGen edge) n --TODO make retry limit configurable
         pure $ (modelAbstraction abstraction) .~ nn $ m
   }
 
@@ -77,9 +75,9 @@ composeEdges a b =
     , match = match a :&&: match b
     , contract = contract a >> contract b
     , permuteGen = do
-        m <- ask
-        ma <- lift $ runGenPA (permuteGen a) m
-        lift $ runGenPA (permuteGen b) ma
+        m <- source
+        ma <- liftEdge (permuteGen a) m
+        liftEdge (permuteGen b) ma
     }
 
 

--- a/src/Apropos/HasPermutationGenerator/Abstraction.hs
+++ b/src/Apropos/HasPermutationGenerator/Abstraction.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE RankNTypes #-}
+module Apropos.HasPermutationGenerator.Abstraction (
+  Abstraction(..),
+  abstract,
+  abstractsProperties,
+  (|:->),
+  ) where
+import Apropos.LogicalModel.Enumerable
+import Apropos.LogicalModel.Formula
+import Apropos.HasPermutationGenerator.Contract
+import Apropos.HasPermutationGenerator.PermutationEdge
+import Apropos.Gen
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Either (rights)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Reader (ask) --TODO refactor gen monad abstraction
+import Control.Lens
+
+data Abstraction ap am bp bm =
+  Abstraction {
+    abstractionName :: String
+  , propertyAbstraction :: Prism' bp ap
+  , modelAbstraction :: Lens' bm am
+  }
+
+abstract :: Enumerable ap
+             => Enumerable bp
+             => Abstraction ap am bp bm -> PermutationEdge ap am -> PermutationEdge bp bm
+abstract abstraction edge =
+  PermutationEdge {
+    name = (abstractionName abstraction) <> name edge
+  , match = ((propertyAbstraction abstraction) #) <$> match edge
+  , contract = abstractContract (abstractionName abstraction)
+                                (propertyAbstraction abstraction) $ contract edge
+  , permuteGen = do
+        m <- ask
+        let n = m ^. (modelAbstraction abstraction)
+        nn <- lift $ runGenPA (permuteGen edge) n
+        pure $ (modelAbstraction abstraction) .~ nn $ m
+  }
+
+abstractsProperties :: Enumerable a => Enumerable b => (a -> b) -> Prism' b a
+abstractsProperties injection = prism' injection (computeProjection injection)
+  where
+    computeProjection :: Enumerable a => Enumerable b => (a -> b) -> (b -> Maybe a)
+    computeProjection f = g
+      where g b = lookup b (zip (f <$> enumerated) enumerated)
+
+abstractContract :: (Ord a, Ord b) => String -> Prism' b a -> Contract a () -> Contract b ()
+abstractContract prefix a c = do
+  i <- readContractOutput
+  n <- readContractEdgeName
+  let subm = projectProperties a i
+      subx = maskProperties a i
+      res = runContract c (prefix <> n) subm
+  case res of
+    Left err -> contractError err
+    Right Nothing -> terminal
+    Right (Just upd) ->
+      output (subx `Set.union` injectProperties a upd)
+  where
+    injectProperties :: Ord b => Prism' b a -> Set a -> Set b
+    injectProperties pa = Set.map (pa #)
+    projectProperties :: Ord a => Prism' b a -> Set b -> Set a
+    projectProperties pa s = Set.fromList $ rights ((matching pa) <$> Set.toList s)
+    maskProperties :: Prism' b a -> Set b -> Set b
+    maskProperties pa = Set.filter (isn't pa)
+
+(|:->) :: [PermutationEdge p m] -> [PermutationEdge p m] -> [PermutationEdge p m]
+(|:->) as bs = [composeEdges a b | a <- as, b <- bs]
+
+composeEdges :: PermutationEdge p m -> PermutationEdge p m -> PermutationEdge p m
+composeEdges a b =
+  PermutationEdge
+    { name = name a <> name b
+    , match = match a :&&: match b
+    , contract = contract a >> contract b
+    , permuteGen = do
+        m <- ask
+        ma <- lift $ runGenPA (permuteGen a) m
+        lift $ runGenPA (permuteGen b) ma
+    }
+
+

--- a/src/Apropos/HasPermutationGenerator/Abstraction.hs
+++ b/src/Apropos/HasPermutationGenerator/Abstraction.hs
@@ -3,10 +3,8 @@ module Apropos.HasPermutationGenerator.Abstraction (
   Abstraction(..),
   abstract,
   abstractsProperties,
-  (|:->),
   ) where
 import Apropos.LogicalModel.Enumerable
-import Apropos.LogicalModel.Formula
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.HasPermutationGenerator.Morphism
 import Apropos.Gen
@@ -23,8 +21,8 @@ data Abstraction ap am bp bm =
   }
 
 abstract :: Enumerable ap
-             => Enumerable bp
-             => Abstraction ap am bp bm -> Morphism ap am -> Morphism bp bm
+         => Enumerable bp
+         => Abstraction ap am bp bm -> Morphism ap am -> Morphism bp bm
 abstract abstraction edge =
   Morphism {
     name = (abstractionName abstraction) <> name edge
@@ -64,20 +62,4 @@ abstractContract prefix a c = do
     projectProperties pa s = Set.fromList $ rights ((matching pa) <$> Set.toList s)
     maskProperties :: Prism' b a -> Set b -> Set b
     maskProperties pa = Set.filter (isn't pa)
-
-(|:->) :: [Morphism p m] -> [Morphism p m] -> [Morphism p m]
-(|:->) as bs = [composeMorphisms a b | a <- as, b <- bs]
-
-composeMorphisms :: Morphism p m -> Morphism p m -> Morphism p m
-composeMorphisms a b =
-  Morphism
-    { name = name a <> name b
-    , match = match a :&&: match b
-    , contract = contract a >> contract b
-    , morphism = do
-        m <- source
-        ma <- liftMorphism (morphism a) m
-        liftMorphism (morphism b) ma
-    }
-
 

--- a/src/Apropos/HasPermutationGenerator/Contract.hs
+++ b/src/Apropos/HasPermutationGenerator/Contract.hs
@@ -1,10 +1,12 @@
 module Apropos.HasPermutationGenerator.Contract (
   Contract,
+  PropertyProjection(..),
+  projection,
   runContract,
   readContractInput,
   readContractEdgeName,
   readContractOutput,
-  setContractOutput,
+  writeContractOutput,
   branches,
   branchIf,
   has,
@@ -24,10 +26,11 @@ module Apropos.HasPermutationGenerator.Contract (
 ) where
 
 import Control.Monad.Reader (ReaderT, ask, runReaderT)
-import Control.Monad.State (StateT, get, modify, put, runStateT)
+import Control.Monad.State (StateT, get, put, runStateT)
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Maybe (MaybeT, runMaybeT)
-import Data.Maybe (catMaybes)
+import Control.Monad.Free
+import Data.Maybe (catMaybes,isNothing)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.String (fromString)
@@ -40,33 +43,97 @@ import Text.PrettyPrint (
  )
 import Text.Show.Pretty (ppDoc)
 
-type Contract p a = MaybeT (ReaderT (String, Set p) (StateT (Set p) (Either String))) a
+data FreeContract p next =
+    ReadContractInput (Set p -> next)
+  | ReadContractEdgeName (String -> next)
+  | ReadContractOutput (Set p -> next)
+  | WriteContractOutput (Set p) next
+  | ContractError String next
+  | Terminal next
 
-runContract :: Contract p () -> String -> Set p -> Either String (Maybe (Set p))
-runContract c nm s = do
-  (b, s') <- runStateT (runReaderT (runMaybeT c) (nm, s)) s
-  case b of
-    Just () -> pure $ Just s'
-    Nothing -> pure Nothing
+instance Functor (FreeContract p) where
+  fmap f (ReadContractInput r) = ReadContractInput (f . r)
+  fmap f (ReadContractEdgeName r) = ReadContractEdgeName (f . r)
+  fmap f (ReadContractOutput r) = ReadContractOutput (f . r)
+  fmap f (WriteContractOutput r next) = WriteContractOutput r (f next)
+  fmap f (ContractError err next) = ContractError err (f next)
+  fmap f (Terminal next) = Terminal (f next)
 
-runContractInternal :: Contract p () -> String -> Set p -> Set p -> Either String (Maybe (Set p))
-runContractInternal c nm s i = do
-  (b, s') <- runStateT (runReaderT (runMaybeT c) (nm, s)) i
-  case b of
-    Just () -> pure $ Just s'
-    Nothing -> pure Nothing
+data PropertyProjection b a = PropertyProjection {
+    projectionName :: String
+  , projectionFunction :: b -> Maybe a
+  , injectionFunction :: a -> b
+  }
+
+projection :: Ord a => Ord b => PropertyProjection b a -> Contract a () -> Contract b ()
+projection p c = do
+  i <- readContractOutput
+  n <- readContractEdgeName
+  let subm = extractSubmodel (projectionFunction p) i
+      subx = exciseSubmodel (projectionFunction p) i
+      res = runContract c ((projectionName p) <> n) subm
+  case res of
+    Left err -> contractError err
+    Right Nothing -> terminal
+    Right (Just upd) ->
+      output (subx `Set.union` (Set.map (injectionFunction p) upd))
+  where
+    extractSubmodel :: Ord p => (q -> Maybe p) -> Set q -> Set p
+    extractSubmodel f q = Set.fromList $ catMaybes (f <$> Set.toList q)
+    exciseSubmodel :: (q -> Maybe p) -> Set q -> Set q
+    exciseSubmodel f q = Set.filter (isNothing . f) q
+
+type Contract p = Free (FreeContract p)
 
 readContractInput :: Contract p (Set p)
-readContractInput = snd <$> lift ask
+readContractInput = liftF (ReadContractInput id)
 
 readContractEdgeName :: Contract p String
-readContractEdgeName = fst <$> lift ask
+readContractEdgeName = liftF (ReadContractEdgeName id)
 
 readContractOutput :: Contract p (Set p)
-readContractOutput = lift $ lift get
+readContractOutput = liftF (ReadContractOutput id)
 
-setContractOutput :: Set p -> Contract p ()
-setContractOutput = lift . lift . put
+writeContractOutput :: Set p -> Contract p ()
+writeContractOutput s = liftF (WriteContractOutput s ())
+
+contractError :: String -> Contract p ()
+contractError s = liftF (ContractError s ())
+
+terminal :: Contract p ()
+terminal = liftF (Terminal ())
+
+type ContractRun p a = MaybeT (ReaderT (String, Set p) (StateT (Set p) (Either String))) a
+
+interpret :: Contract p () -> ContractRun p ()
+interpret (Free (ReadContractInput next))     = (snd <$> lift ask) >>= interpret . next
+interpret (Free (ReadContractEdgeName next))  = (fst <$> lift ask) >>= interpret . next
+interpret (Free (ReadContractOutput next))    = (lift $ lift get)  >>= interpret . next
+interpret (Free (WriteContractOutput s next)) = (lift $ lift $ put s) >> interpret next
+interpret (Free (ContractError err next))     = (lift $ lift $ lift $ Left err) >> interpret next
+interpret (Free (Terminal next))              = fail "terminal" >> interpret next
+interpret (Pure a)                            = pure a
+
+runContract :: Contract p () -> String -> Set p -> Either String (Maybe (Set p))
+runContract = runContract' . interpret
+  where
+    runContract' :: ContractRun p () -> String -> Set p -> Either String (Maybe (Set p))
+    runContract' c nm s = do
+      (b, s') <- runStateT (runReaderT (runMaybeT c) (nm, s)) s
+      case b of
+        Just () -> pure $ Just s'
+        Nothing -> pure Nothing
+
+runContractInternal :: Contract p () -> String -> Set p -> Set p -> Contract p (Maybe (Set p))
+runContractInternal = runContractInternal' . interpret
+  where
+    runContractInternal' :: ContractRun p () -> String -> Set p -> Set p -> Contract p (Maybe (Set p))
+    runContractInternal' c nm s i = do
+      case runStateT (runReaderT (runMaybeT c) (nm, s)) i of
+        Left err -> contractError err >> pure Nothing
+        Right (b, s') -> case b of
+                           Just () -> pure $ Just s'
+                           Nothing -> pure Nothing
 
 --e.g. has ThisThing >> add ThatThing
 has :: Eq p => p -> Contract p ()
@@ -74,7 +141,7 @@ has p = do
   s <- readContractInput
   if p `elem` s
     then pure ()
-    else fail "Nothing"
+    else terminal
 
 --e.g. hasAll [ThisThing,ThatThing] >> add TheOtherThing
 hasAll :: Eq p => [p] -> Contract p ()
@@ -85,7 +152,7 @@ hasn't :: Eq p => p -> Contract p ()
 hasn't p = do
   s <- readContractInput
   if p `elem` s
-    then fail "Nothing"
+    then terminal
     else pure ()
 
 --e.g. hasNone [ThisThing,ThatThing] >> add TheOtherThing
@@ -93,10 +160,10 @@ hasNone :: Eq p => [p] -> Contract p ()
 hasNone = mapM_ hasn't
 
 add :: Ord p => p -> Contract p ()
-add p = lift $ lift $ modify (Set.insert p)
+add p = readContractOutput >>= writeContractOutput . Set.insert p
 
 remove :: Ord p => p -> Contract p ()
-remove p = lift $ lift $ modify (Set.delete p)
+remove p = readContractOutput >>= writeContractOutput . Set.delete p
 
 addAll :: Ord p => [p] -> Contract p ()
 addAll = mapM_ add
@@ -105,10 +172,10 @@ removeAll :: Ord p => [p] -> Contract p ()
 removeAll = mapM_ remove
 
 clear :: Contract p ()
-clear = lift $ lift $ put Set.empty
+clear = writeContractOutput Set.empty
 
 output :: Set p -> Contract p ()
-output = lift . lift . put
+output = writeContractOutput
 
 addIf :: (Ord p, Show p) => p -> p -> Contract p ()
 addIf p q = branches [has p >> add q, hasn't p]
@@ -130,19 +197,14 @@ branches cs = do
   i <- readContractInput
   e <- readContractEdgeName
   o <- readContractOutput
-  rs <- mapM (\c -> lift $ lift $ lift $ runContractInternal c e i o) cs
+  rs <- mapM (\c -> runContractInternal c e i o) cs
   case catMaybes rs of
-    [] -> fail "Nothing"
-    [ao] -> setContractOutput ao >> pure ()
+    [] -> terminal
+    [ao] -> writeContractOutput ao
     (ao : rest) ->
       if all (== ao) rest
-        then setContractOutput ao >> pure ()
-        else
-          lift $
-            lift $
-              lift $
-                Left $
-                  renderStyle ourStyle $
+        then writeContractOutput ao
+        else contractError $ renderStyle ourStyle $
                     (fromString $ "PermutationEdge " <> e <> " has non-deterministic type")
                       $+$ hang "error:" 4 "branches succeeded with different results in each branch."
                       $+$ hang "results:" 4 (ppDoc (ao : rest))

--- a/src/Apropos/HasPermutationGenerator/Morphism.hs
+++ b/src/Apropos/HasPermutationGenerator/Morphism.hs
@@ -1,22 +1,22 @@
 {-# LANGUAGE RankNTypes #-}
 
-module Apropos.HasPermutationGenerator.PermutationEdge (
-  PermutationEdge (..),
+module Apropos.HasPermutationGenerator.Morphism (
+  Morphism (..),
 ) where
 
 import Apropos.Gen
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.LogicalModel.Formula
 
-data PermutationEdge p m = PermutationEdge
+data Morphism p m = Morphism
   { name :: String
   , match :: Formula p
   , contract :: Contract p ()
-  , permuteGen :: Gen m m
+  , morphism :: Gen m m
   }
 
-instance Eq (PermutationEdge p m) where
+instance Eq (Morphism p m) where
   (==) a b = name a == name b
 
-instance Show (PermutationEdge p m) where
+instance Show (Morphism p m) where
   show = name

--- a/src/Apropos/HasPermutationGenerator/Morphism.hs
+++ b/src/Apropos/HasPermutationGenerator/Morphism.hs
@@ -13,7 +13,7 @@ data Morphism p m = Morphism
   { name :: String
   , match :: Formula p
   , contract :: Contract p ()
-  , morphism :: Gen m m
+  , morphism :: m -> Gen m
   }
 
 instance Eq (Morphism p m) where
@@ -31,10 +31,7 @@ composeMorphisms a b =
     { name = name a <> name b
     , match = match a :&&: match b
     , contract = contract a >> contract b
-    , morphism = do
-        m <- source
-        ma <- liftMorphism (morphism a) m
-        liftMorphism (morphism b) ma
+    , morphism = \m -> (morphism a) m >>= morphism b
     }
 
 

--- a/src/Apropos/HasPermutationGenerator/Morphism.hs
+++ b/src/Apropos/HasPermutationGenerator/Morphism.hs
@@ -2,6 +2,7 @@
 
 module Apropos.HasPermutationGenerator.Morphism (
   Morphism (..),
+  (|:->),
 ) where
 
 import Apropos.Gen
@@ -20,3 +21,20 @@ instance Eq (Morphism p m) where
 
 instance Show (Morphism p m) where
   show = name
+
+(|:->) :: [Morphism p m] -> [Morphism p m] -> [Morphism p m]
+(|:->) as bs = [composeMorphisms a b | a <- as, b <- bs]
+
+composeMorphisms :: Morphism p m -> Morphism p m -> Morphism p m
+composeMorphisms a b =
+  Morphism
+    { name = name a <> name b
+    , match = match a :&&: match b
+    , contract = contract a >> contract b
+    , morphism = do
+        m <- source
+        ma <- liftMorphism (morphism a) m
+        liftMorphism (morphism b) ma
+    }
+
+

--- a/src/Apropos/HasPermutationGenerator/PermutationEdge.hs
+++ b/src/Apropos/HasPermutationGenerator/PermutationEdge.hs
@@ -2,15 +2,11 @@
 
 module Apropos.HasPermutationGenerator.PermutationEdge (
   PermutationEdge (..),
-  (<$$>),
-  (<*>>),
 ) where
 
 import Apropos.Gen
 import Apropos.HasPermutationGenerator.Contract
 import Apropos.LogicalModel.Formula
-import Control.Monad.Trans (lift)
-import Control.Monad.Trans.Reader (ask)
 
 data PermutationEdge p m = PermutationEdge
   { name :: String
@@ -18,45 +14,6 @@ data PermutationEdge p m = PermutationEdge
   , contract :: Contract p ()
   , permuteGen :: PAGen m m
   }
-
-(<*>>) :: [PermutationEdge p m] -> [PermutationEdge p m] -> [PermutationEdge p m]
-(<*>>) as bs = [composeEdges a b | a <- as, b <- bs]
-
-composeEdges :: PermutationEdge p m -> PermutationEdge p m -> PermutationEdge p m
-composeEdges a b =
-  PermutationEdge
-    { name = name a <> name b
-    , match = match a :&&: match b
-    , contract = contract a >> contract b
-    , permuteGen = do
-        m <- ask
-        ma <- lift $ runGenPA (permuteGen a) m
-        lift $ runGenPA (permuteGen b) ma
-    }
-
-(<$$>) ::
-  (Ord p, Ord q) =>
-  ModelAbstraction q m p n ->
-  [PermutationEdge p n] ->
-  [PermutationEdge q m]
-(<$$>) abstraction edges = liftEdge abstraction <$> edges
-
-liftEdge ::
-  (Ord p, Ord q) =>
-  ModelAbstraction q m p n ->
-  PermutationEdge p n ->
-  PermutationEdge q m
-liftEdge abstraction edge =
-  PermutationEdge
-    { name = ((abstractionName abstraction) <> name edge)
-    , match = (injectProperty abstraction) <$> match edge
-    , contract = propertyAbstraction abstraction $ contract edge
-    , permuteGen = do
-        m <- ask
-        let n = (projectSubmodel abstraction) m
-        nn <- lift $ runGenPA (permuteGen edge) n
-        pure $ (injectSubmodel abstraction) nn m
-    }
 
 instance Eq (PermutationEdge p m) where
   (==) a b = name a == name b

--- a/src/Apropos/HasPermutationGenerator/PermutationEdge.hs
+++ b/src/Apropos/HasPermutationGenerator/PermutationEdge.hs
@@ -12,7 +12,7 @@ data PermutationEdge p m = PermutationEdge
   { name :: String
   , match :: Formula p
   , contract :: Contract p ()
-  , permuteGen :: PAGen m m
+  , permuteGen :: Gen m m
   }
 
 instance Eq (PermutationEdge p m) where

--- a/src/Apropos/LogicalModel/Enumerable.hs
+++ b/src/Apropos/LogicalModel/Enumerable.hs
@@ -2,5 +2,5 @@ module Apropos.LogicalModel.Enumerable (
   Enumerable (..),
 ) where
 
-class Enumerable p where
+class (Eq p, Ord p) => Enumerable p where
   enumerated :: [p]

--- a/src/Apropos/LogicalModel/Formula.hs
+++ b/src/Apropos/LogicalModel/Formula.hs
@@ -34,23 +34,6 @@ data Formula v
   | AtMostOne [Formula v]
   deriving stock (Generic, Functor)
 
-instance Applicative Formula where
-  pure a = Var a
-  (<*>) (Var aTob) (Var a) = Var (aTob a)
-  (<*>) (Var aTob) a = aTob <$> a
-  (<*>) Yes Yes = Yes
-  (<*>) (aTobL :&&:  aTobR) a = (aTobL <*> a) :&&:  (aTobR <*> a)
-  (<*>) (aTobL :||:  aTobR) a = (aTobL <*> a) :||:  (aTobR <*> a)
-  (<*>) (aTobL :++:  aTobR) a = (aTobL <*> a) :++:  (aTobR <*> a)
-  (<*>) (aTobL :->:  aTobR) a = (aTobL <*> a) :->:  (aTobR <*> a)
-  (<*>) (aTobL :<->: aTobR) a = (aTobL <*> a) :<->: (aTobR <*> a)
-  (<*>) (All        aTobs) a = All         [ aTob <*> a | aTob <- aTobs ]
-  (<*>) (Some       aTobs) a = Some        [ aTob <*> a | aTob <- aTobs ]
-  (<*>) (None       aTobs) a = None        [ aTob <*> a | aTob <- aTobs ]
-  (<*>) (ExactlyOne aTobs) a = ExactlyOne  [ aTob <*> a | aTob <- aTobs ]
-  (<*>) (AtMostOne  aTobs) a = AtMostOne   [ aTob <*> a | aTob <- aTobs ]
-  (<*>) _ _ = No
-
 translateToSAT :: Formula v -> S.Formula v
 translateToSAT (Var v) = S.Var v
 translateToSAT Yes = S.Yes

--- a/src/Apropos/Pure.hs
+++ b/src/Apropos/Pure.hs
@@ -15,7 +15,7 @@ class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasPureRunner p m 
 
   runPureTest :: m :+ p -> Set p -> Property
   runPureTest apropos s = property $ do
-    (m :: m) <- handleRootRetries numRetries $ genRoot $ parameterisedGenerator s
+    (m :: m) <- handleRootRetries numRetries $ gen $ parameterisedGenerator s
     satisfiesFormula (expect apropos) s === (script apropos) m
     where
       numRetries :: Int

--- a/src/Apropos/Pure.hs
+++ b/src/Apropos/Pure.hs
@@ -1,30 +1,27 @@
 module Apropos.Pure (HasPureRunner (..)) where
-
+import Apropos.Type
 import Apropos.HasLogicalModel
 import Apropos.HasParameterisedGenerator
 import Apropos.LogicalModel
 import Apropos.Gen
-import Data.Proxy (Proxy (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.String (fromString)
 import Hedgehog (Group (..), Property, property, (===))
 
 class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasPureRunner p m where
-  expect :: Proxy m -> Formula p
-  script :: Proxy p -> m -> Bool
+  expect :: m :+ p -> Formula p
+  script :: m :+ p -> (m -> Bool)
 
-  runPureTest :: Proxy m -> Set p -> Property
-  runPureTest pm s = property $ do
+  runPureTest :: m :+ p -> Set p -> Property
+  runPureTest apropos s = property $ do
     (m :: m) <- handleRootRetries numRetries $ genRoot $ parameterisedGenerator s
-    let expect' = expect pm
-        script' = script (Proxy :: Proxy p)
-    satisfiesFormula expect' s === script' m
+    satisfiesFormula (expect apropos) s === (script apropos) m
     where
       numRetries :: Int
-      numRetries = rootRetryLimit (Proxy :: Proxy (m,p))
+      numRetries = rootRetryLimit (Apropos :: m :+ p)
 
-  runPureTestsWhere :: Proxy m -> String -> Formula p -> Group
+  runPureTestsWhere :: m :+ p -> String -> Formula p -> Group
   runPureTestsWhere pm name condition =
     Group (fromString name) $
       [ ( fromString $ show $ Set.toList scenario
@@ -32,3 +29,4 @@ class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasPureRunner p m 
         )
       | scenario <- enumerateScenariosWhere condition
       ]
+

--- a/src/Apropos/Script.hs
+++ b/src/Apropos/Script.hs
@@ -79,7 +79,7 @@ class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasScriptRunner p 
     m :+ p ->
     m ->
     Either ([Text], String) (ExBudget, [Text]) ->
-    Gen m ()
+    Gen ()
   deliverResult apropos model res =
     case (shouldPass, res) of
       (False, Left _) -> pure ()
@@ -89,7 +89,7 @@ class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasScriptRunner p 
     where
       shouldPass :: Bool
       shouldPass = satisfiesFormula (expect apropos) $ properties model
-      successWithBudgetCheck :: ExBudget -> Gen m ()
+      successWithBudgetCheck :: ExBudget -> Gen ()
       successWithBudgetCheck cost@(ExBudget cpu mem) =
         if inInterval cpu (modelCPUBounds apropos model) && inInterval mem (modelMemoryBounds apropos model)
           then pure ()

--- a/src/Apropos/Type.hs
+++ b/src/Apropos/Type.hs
@@ -1,0 +1,8 @@
+module Apropos.Type (
+  Apropos(..),
+  (:+),
+  ) where
+
+type (type' :+ logic') = Apropos (type',logic')
+
+data Apropos a = Apropos


### PR DESCRIPTION
Refactor morphism to be cleaner. This gets rid of the ReaderT in the stack and renames `permuteGen` to `morphism :: m -> Gen m`.