### PR TITLE
add runners for enumeration (reduces test duplication when enumerable)

### DIFF
--- a/examples/Spec/Plutarch/CostModel.hs
+++ b/examples/Spec/Plutarch/CostModel.hs
@@ -78,7 +78,7 @@ addCostModelPlutarchTests :: TestTree
 addCostModelPlutarchTests =
   testGroup "Plutarch.AdditionCostModel" $
     fromGroup
-      <$> [ runScriptTestsWhere
+      <$> [ enumerateScriptTestsWhere
               (Apropos :: Integer :+ CostModelProp)
               "AdditionCostModel"
               Yes

--- a/examples/Spec/Plutarch/MagicNumber.hs
+++ b/examples/Spec/Plutarch/MagicNumber.hs
@@ -57,7 +57,7 @@ magicNumberPropGenTests :: TestTree
 magicNumberPropGenTests =
   testGroup "Spec.Plutarch.MagicNumber" $
     fromGroup
-      <$> [ runGeneratorTestsWhere
+      <$> [ enumerateGeneratorTestsWhere
               (Apropos :: Script :+ MagicNumberProp)
               "Magic Number Script Generator"
               Yes

--- a/src/Apropos.hs
+++ b/src/Apropos.hs
@@ -33,7 +33,6 @@ module Apropos (
   runGeneratorTestsWhere,
   enumerateGeneratorTest,
   enumerateGeneratorTestsWhere,
-
   genSatisfying,
   -- Apropos.HasPermutationGenerator
   HasPermutationGenerator (..),

--- a/src/Apropos.hs
+++ b/src/Apropos.hs
@@ -31,6 +31,9 @@ module Apropos (
   HasParameterisedGenerator (..),
   runGeneratorTest,
   runGeneratorTestsWhere,
+  enumerateGeneratorTest,
+  enumerateGeneratorTestsWhere,
+
   genSatisfying,
   -- Apropos.HasPermutationGenerator
   HasPermutationGenerator (..),

--- a/src/Apropos/HasParameterisedGenerator.hs
+++ b/src/Apropos/HasParameterisedGenerator.hs
@@ -15,8 +15,7 @@ import Apropos.Type
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String (fromString)
-import Hedgehog (Group (..), Property, TestLimit, withTests, property, (===))
-import Control.Monad (void)
+import Hedgehog (Group (..), Property, TestLimit, property, withTests, (===))
 
 class (HasLogicalModel p m, Show m) => HasParameterisedGenerator p m where
   parameterisedGenerator :: Set p -> Gen m
@@ -55,10 +54,11 @@ enumerateGeneratorTest ::
   m :+ p ->
   Set p ->
   Property
-enumerateGeneratorTest _ s = withTests (1 :: TestLimit) $ property $ do
-  let (ms :: [m]) = enumerate $ parameterisedGenerator s
-      run m = properties m === s
-  void $ sequence (run <$> ms)
+enumerateGeneratorTest _ s = withTests (1 :: TestLimit) $
+  property $ do
+    let (ms :: [m]) = enumerate $ parameterisedGenerator s
+        run m = properties m === s
+    sequence_ (run <$> ms)
 
 enumerateGeneratorTestsWhere ::
   HasParameterisedGenerator p m =>
@@ -71,7 +71,6 @@ enumerateGeneratorTestsWhere proxy name condition =
     [ (fromString $ show $ Set.toList scenario, enumerateGeneratorTest proxy scenario)
     | scenario <- enumerateScenariosWhere condition
     ]
-
 
 genSatisfying :: HasParameterisedGenerator p m => Formula p -> Gen m
 genSatisfying f = do

--- a/src/Apropos/Pure.hs
+++ b/src/Apropos/Pure.hs
@@ -9,8 +9,7 @@ import Apropos.Type
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String (fromString)
-import Hedgehog (Group (..), Property, TestLimit, withTests, property, (===))
-import Control.Monad (void)
+import Hedgehog (Group (..), Property, TestLimit, property, withTests, (===))
 
 class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasPureRunner p m where
   expect :: m :+ p -> Formula p
@@ -34,10 +33,11 @@ class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasPureRunner p m 
       ]
 
   enumeratePureTest :: m :+ p -> Set p -> Property
-  enumeratePureTest apropos s =  withTests (1 :: TestLimit) $ property $ do
-    let (ms :: [m]) = enumerate $ parameterisedGenerator s
-        run m = satisfiesFormula (expect apropos) s === script apropos m
-    void $ sequence (run <$> ms)
+  enumeratePureTest apropos s = withTests (1 :: TestLimit) $
+    property $ do
+      let (ms :: [m]) = enumerate $ parameterisedGenerator s
+          run m = satisfiesFormula (expect apropos) s === script apropos m
+      sequence_ (run <$> ms)
 
   enumeratePureTestsWhere :: m :+ p -> String -> Formula p -> Group
   enumeratePureTestsWhere pm name condition =

--- a/src/Apropos/Pure.hs
+++ b/src/Apropos/Pure.hs
@@ -1,6 +1,7 @@
 module Apropos.Pure (HasPureRunner (..)) where
 
 import Apropos.Gen
+import Apropos.Gen.Enumerate
 import Apropos.HasLogicalModel
 import Apropos.HasParameterisedGenerator
 import Apropos.LogicalModel
@@ -8,7 +9,8 @@ import Apropos.Type
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String (fromString)
-import Hedgehog (Group (..), Property, property, (===))
+import Hedgehog (Group (..), Property, TestLimit, withTests, property, (===))
+import Control.Monad (void)
 
 class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasPureRunner p m where
   expect :: m :+ p -> Formula p
@@ -27,6 +29,21 @@ class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasPureRunner p m 
     Group (fromString name) $
       [ ( fromString $ show $ Set.toList scenario
         , runPureTest pm scenario
+        )
+      | scenario <- enumerateScenariosWhere condition
+      ]
+
+  enumeratePureTest :: m :+ p -> Set p -> Property
+  enumeratePureTest apropos s =  withTests (1 :: TestLimit) $ property $ do
+    let (ms :: [m]) = enumerate $ parameterisedGenerator s
+        run m = satisfiesFormula (expect apropos) s === script apropos m
+    void $ sequence (run <$> ms)
+
+  enumeratePureTestsWhere :: m :+ p -> String -> Formula p -> Group
+  enumeratePureTestsWhere pm name condition =
+    Group (fromString name) $
+      [ ( fromString $ show $ Set.toList scenario
+        , enumeratePureTest pm scenario
         )
       | scenario <- enumerateScenariosWhere condition
       ]

--- a/src/Apropos/Script.hs
+++ b/src/Apropos/Script.hs
@@ -47,10 +47,10 @@ import Prelude (
   sequence,
   snd,
   zip,
-  (<$>),
   ($),
   (&&),
   (.),
+  (<$>),
   (<=),
   (<>),
   (>=),
@@ -89,13 +89,14 @@ class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasScriptRunner p 
       ]
 
   enumerateScriptTest :: m :+ p -> Set p -> Property
-  enumerateScriptTest apropos targetProperties = withTests (1 :: TestLimit) $ genProp $ do
-    let ms = enumerate $ parameterisedGenerator targetProperties
-    let run m = case evaluateScript $ script apropos m of
-                  Left (EvaluationError logs err) -> deliverResult apropos m (Left (logs, err))
-                  Right res -> deliverResult apropos m (Right res)
-                  Left err -> failWithFootnote (show err)
-    sequence (run <$> ms)
+  enumerateScriptTest apropos targetProperties = withTests (1 :: TestLimit) $
+    genProp $ do
+      let ms = enumerate $ parameterisedGenerator targetProperties
+      let run m = case evaluateScript $ script apropos m of
+            Left (EvaluationError logs err) -> deliverResult apropos m (Left (logs, err))
+            Right res -> deliverResult apropos m (Right res)
+            Left err -> failWithFootnote (show err)
+      sequence (run <$> ms)
 
   deliverResult ::
     m :+ p ->


### PR DESCRIPTION
Some specifications we can enumerate entirely. It would be nice to specify this in a more granular way but for now I have implemented top level runners that do the enumeration at time of property test creation.