### PR TITLE
add ability to catch retries in Gen

### DIFF
--- a/examples/Spec/IntPermutationGen.hs
+++ b/examples/Spec/IntPermutationGen.hs
@@ -132,3 +132,5 @@ intPermutationGenSelfTests =
         True
         (\(_ :: Morphism IntProp Int) -> True)
         baseGen
+
+

--- a/src/Apropos/Gen.hs
+++ b/src/Apropos/Gen.hs
@@ -15,6 +15,9 @@ module Apropos.Gen (
   choice,
   genFilter,
   retry,
+  onRetry,
+  retryLimit,
+  (===),
   Range,
   linear,
   singleton,
@@ -66,7 +69,8 @@ data FreeGen next where
     Gen a ->
     (a -> next) ->
     FreeGen next
-  RootRetry :: forall a next. (a -> next) -> FreeGen next
+  ThrowRetry :: forall a next. (a -> next) -> FreeGen next
+  OnRetry :: forall a next. Gen a -> Gen a -> (a -> next) -> FreeGen next
 
 instance Functor FreeGen where
   fmap f (Label l next) = Label l (f next)
@@ -78,7 +82,8 @@ instance Functor FreeGen where
   fmap f (GenElement ls next) = GenElement ls (f . next)
   fmap f (GenChoice gs next) = GenChoice gs (f . next)
   fmap f (GenFilter c g next) = GenFilter c g (f . next)
-  fmap f (RootRetry next) = RootRetry (f . next)
+  fmap f (ThrowRetry next) = ThrowRetry (f . next)
+  fmap f (OnRetry a b next) = OnRetry a b (f . next)
 
 type Gen = Free FreeGen
 
@@ -110,10 +115,27 @@ genFilter :: Show a => (a -> Bool) -> Gen a -> Gen a
 genFilter c g = liftF (GenFilter c g id)
 
 retry :: Gen a
-retry = liftF (RootRetry id)
+retry = liftF (ThrowRetry id)
+
+onRetry :: Gen a -> Gen a -> Gen a
+onRetry a b = liftF (OnRetry a b id)
+
+retryLimit :: forall a . Int -> Gen a -> Gen a -> Gen a
+retryLimit lim g done = go lim
+  where
+    go :: Int -> Gen a
+    go i = if i == 0
+              then done
+              else onRetry g (go (i - 1))
 
 genProp :: Gen a -> Property
 genProp g = H.property $ void $ runExceptT $ gen g
+
+(===) :: (Eq a, Show a) => a -> a -> Gen ()
+(===) l r =
+  if l == r
+     then pure ()
+     else failWithFootnote $ "expected: " <> show l <> " === " <> show r
 
 data GenException = GenException String | Retry deriving stock (Show)
 
@@ -146,7 +168,13 @@ gen (Free (GenChoice gs next)) = do
       (gs !! i) >>== next
 gen (Free (GenFilter c g next)) = do
   genFilter' c g >>>= next
-gen (Free (RootRetry _)) = throwE Retry
+gen (Free (ThrowRetry _)) = throwE Retry
+gen (Free (OnRetry a b next)) = do
+  res <- lift $ runExceptT (gen a)
+  case res of
+    Right r -> gen $ next r
+    Left Retry -> gen b >>= (gen . next)
+    Left err -> throwE err
 gen (Pure a) = pure a
 
 (>>==) :: Gen r -> (r -> Gen a) -> Generator a

--- a/src/Apropos/Gen/Enumerate.hs
+++ b/src/Apropos/Gen/Enumerate.hs
@@ -28,7 +28,8 @@ enumerate (Free (GenChoice gs next)) = do
   (>>== next) =<< gs
 enumerate (Free (GenFilter c g next)) = do
   filter c (enumerate g) >>>= next
-enumerate (Free (RootRetry _)) = error "enumerate can't retry"
+enumerate (Free (ThrowRetry _)) = error "enumerate can't retry"
+enumerate (Free (OnRetry _ _ _)) = error "maybe it can..."
 enumerate (Pure a) = pure a
 
 (>>==) :: Gen r -> (r -> Gen a) -> [a]

--- a/src/Apropos/HasParameterisedGenerator.hs
+++ b/src/Apropos/HasParameterisedGenerator.hs
@@ -7,7 +7,7 @@ module Apropos.HasParameterisedGenerator (
   genSatisfying,
 ) where
 
-import Apropos.Gen
+import Apropos.Gen hiding ((===))
 import Apropos.Gen.Enumerate
 import Apropos.HasLogicalModel
 import Apropos.LogicalModel

--- a/src/Apropos/Pure.hs
+++ b/src/Apropos/Pure.hs
@@ -1,6 +1,6 @@
 module Apropos.Pure (HasPureRunner (..)) where
 
-import Apropos.Gen
+import Apropos.Gen hiding ((===))
 import Apropos.Gen.Enumerate
 import Apropos.HasLogicalModel
 import Apropos.HasParameterisedGenerator


### PR DESCRIPTION
Lift retry handling into the Gen monad. Now we can wrap arbitrary Gen computations that may throw a Retry and provide a handler for when they do.