### PR TITLE
sketch of arrow constraint dsl

### DIFF
--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -69,6 +69,7 @@ library
                  , Apropos.Script.Iso.Arrow.Runner
                  , Apropos.Script.Iso.Constraint
                  , Apropos.Script.Iso.Constraint.Runner
+                 , Apropos.Script.Iso.DSL
                  , Apropos.Tx
                  , Apropos.Tx.Constraint.Policy
   hs-source-dirs:  src

--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -69,9 +69,9 @@ library
                  , Apropos.Script.Iso.Arrow.Runner
                  , Apropos.Script.Iso.Constraint
                  , Apropos.Script.Iso.Constraint.Runner
-                 , Apropos.Script.Iso.DSL
                  , Apropos.Tx
                  , Apropos.Tx.Constraint.Policy
+                 , Plutarch.ArrowDSL
   hs-source-dirs:  src
 
 test-suite examples

--- a/apropos-tx.cabal
+++ b/apropos-tx.cabal
@@ -72,6 +72,7 @@ library
                  , Apropos.Tx
                  , Apropos.Tx.Constraint.Policy
                  , Plutarch.ArrowDSL
+                 , Plutarch.ShowProxyLiftedType
   hs-source-dirs:  src
 
 test-suite examples

--- a/src/Apropos/Script/Iso/DSL.hs
+++ b/src/Apropos/Script/Iso/DSL.hs
@@ -1,36 +1,35 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Apropos.Script.Iso.DSL (
-  NamedIsoArrow(..),
-  NamedIsoUnaryConstraint(..),
-  NamedIsoBinaryConstraint(..),
-  haskUnaryConstraint,
+  NamedArrow(..),
+  NamedUnaryConstraint(..),
+  NamedBinaryConstraint(..),
+  compileArrow,
+  compileBinaryConstraint,
+  compileUnaryConstraint,
 ) where
 import Plutarch
+import Plutarch.Prelude
 import Plutarch.Lift
 import Plutarch.Api.V1.Tuple
 
-class NamedIsoArrow arrow where
+class NamedArrow arrow where
   arrowName :: arrow s a b -> String
-  isoArrow :: (PLifted a -> PLifted b) -> PlutarchArrow s a b -> arrow s a b
-  hArrow :: arrow s a b -> (PLifted a -> PLifted b)
-  pArrow :: arrow s a b -> PlutarchArrow s a b
+  mkArrow :: PlutarchArrow s a b -> arrow s a b
+  arrow :: arrow s a b -> PlutarchArrow s a b
 
 
-class NamedIsoUnaryConstraint constraint where
+class NamedUnaryConstraint constraint where
   unaryConstraintName :: constraint s a -> String
-  unaryConstraint :: (PLifted a -> Bool) -> PlutarchUnaryConstraint s a -> constraint s a
-  hUnaryConstraint :: constraint s a -> (PLifted a -> Bool)
-  pUnaryConstraint :: constraint s a -> PlutarchUnaryConstraint s a
+  mkUnaryConstraint :: PlutarchUnaryConstraint s a -> constraint s a
+  unaryConstraint :: constraint s a -> PlutarchUnaryConstraint s a
 
-class NamedIsoBinaryConstraint constraint where
+class NamedBinaryConstraint constraint where
   binaryConstraintName :: constraint s a b -> String
-  binaryConstraint :: (PLifted a -> PLifted b -> Bool) -> PlutarchBinaryConstraint s a b -> constraint s a b
-  hBinaryConstraint :: constraint s a b -> (PLifted a -> PLifted b -> Bool)
-  pBinaryConstraint :: constraint s a b -> PlutarchBinaryConstraint s a b
+  mkbinaryConstraint :: PlutarchBinaryConstraint s a b -> constraint s a b
+  binaryConstraint :: constraint s a b -> PlutarchBinaryConstraint s a b
 
-
-type PlutarchArrow s antecedent consequent = Term s (antecedent :--> consequent)
+type PlutarchArrow s a b = Term s (a :--> b)
 
 -- where POpaque is a truthy value e.g. perror = False, PUnit = True
 type PlutarchUnaryConstraint s domain = Term s (domain :--> POpaque)
@@ -39,63 +38,58 @@ type PlutarchUnaryConstraint s domain = Term s (domain :--> POpaque)
 type PlutarchBinaryConstraint s domainL domainR = Term s (domainL :--> domainR :--> POpaque)
 
 
-data IsoArrow s a b where
-  IsoArrow :: NamedIsoArrow arrow => arrow s a b -> IsoArrow s a b
-  IsoArrowSeq :: IsoArrow s a v -> IsoArrow s v b -> IsoArrow s a b
-  IsoArrowFanout :: (b ~ PTuple bl br, PLifted (PTuple bl br) ~ (PLifted bl, PLifted br))
-                 => IsoArrow s a bl -> IsoArrow s a br -> IsoArrow s a b
-  IsoArrowParallel :: (a ~ PTuple al ar, PLifted (PTuple al ar) ~ (PLifted al, PLifted ar)
-                      ,b ~ PTuple bl br, PLifted (PTuple bl br) ~ (PLifted bl, PLifted br))
-                   => IsoArrow s al bl -> IsoArrow s ar br -> IsoArrow s a b
+data Arrow s a b where
+  Arrow :: NamedArrow arrow => arrow s a b -> Arrow s a b
+  ArrowSeq :: Arrow s a v -> Arrow s v b -> Arrow s a b
+  ArrowFanout :: (PIsData bl, PIsData br, b ~ PTuple bl br, PLifted (PTuple bl br) ~ (PLifted bl, PLifted br))
+                 => Arrow s a bl -> Arrow s a br -> Arrow s a b
+  ArrowParallel :: (PIsData al, PIsData ar, a ~ PTuple al ar, PLifted (PTuple al ar) ~ (PLifted al, PLifted ar)
+                   ,PIsData bl, PIsData br, b ~ PTuple bl br, PLifted (PTuple bl br) ~ (PLifted bl, PLifted br))
+                   => Arrow s al bl -> Arrow s ar br -> Arrow s a b
 
-data IsoBinaryConstraint s a b where
-  IsoBinaryConstraint :: NamedIsoBinaryConstraint constraint
-                      => constraint s a b -> IsoBinaryConstraint s a b
-  IsoBinaryConstraintAssoc :: IsoBinaryConstraint s a b -> IsoBinaryConstraint s a b -> IsoBinaryConstraint s a b
-  IsoBinaryConstraintArrowLeft :: IsoArrow s a c -> IsoBinaryConstraint s c b -> IsoBinaryConstraint s a b
-  IsoBinaryConstraintArrowRight :: IsoBinaryConstraint s a c -> IsoArrow s b c -> IsoBinaryConstraint s a b
-  IsoBinaryConstraintArrowParallel :: (ab ~ PTuple a b, PLifted (PTuple a b) ~ (PLifted a, PLifted b)
+data BinaryConstraint s a b where
+  BinaryConstraint :: NamedBinaryConstraint constraint
+                      => constraint s a b -> BinaryConstraint s a b
+  BinaryConstraintFlip :: BinaryConstraint s b a -> BinaryConstraint s a b
+  BinaryConstraintAssoc :: BinaryConstraint s a b -> BinaryConstraint s a b -> BinaryConstraint s a b
+  BinaryConstraintArrowLeft :: Arrow s a c -> BinaryConstraint s c b -> BinaryConstraint s a b
+  BinaryConstraintArrowRight :: BinaryConstraint s a c -> Arrow s b c -> BinaryConstraint s a b
+  BinaryConstraintArrowParallel :: (ab ~ PTuple a b, PLifted (PTuple a b) ~ (PLifted a, PLifted b)
                                       ,v ~ PTuple vl vr, PLifted (PTuple vl vr) ~ (PLifted vl, PLifted vr))
-                                  => IsoArrow s ab v -> IsoBinaryConstraint s vl vr -> IsoBinaryConstraint s a b
+                                  => Arrow s ab v -> BinaryConstraint s vl vr -> BinaryConstraint s a b
 
 
-data IsoUnaryConstraint s a where
-  IsoUnaryConstraint :: NamedIsoUnaryConstraint constraint
-                     => constraint s a -> IsoUnaryConstraint s a
-  IsoUnaryFromBinaryConstraint :: IsoBinaryConstraint s a a -> IsoUnaryConstraint s a
-  IsoUnaryConstraintAssoc :: IsoUnaryConstraint s a -> IsoUnaryConstraint s a -> IsoUnaryConstraint s a
-  IsoUnaryConstraintArrow :: IsoArrow s a b -> IsoUnaryConstraint s b -> IsoUnaryConstraint s a
-  IsoUnaryConstraintFanoutBinary ::  (v ~ PTuple vl vr, PLifted (PTuple vl vr) ~ (PLifted vl, PLifted vr))
-                                  => IsoArrow s a v -> IsoBinaryConstraint s vl vr -> IsoUnaryConstraint s a
+data UnaryConstraint s a where
+  UnaryConstraint :: NamedUnaryConstraint constraint
+                     => constraint s a -> UnaryConstraint s a
+  UnaryFromBinaryConstraint :: BinaryConstraint s a a -> UnaryConstraint s a
+  UnaryConstraintAssoc :: UnaryConstraint s a -> UnaryConstraint s a -> UnaryConstraint s a
+  UnaryConstraintArrow :: Arrow s a b -> UnaryConstraint s b -> UnaryConstraint s a
+  UnaryConstraintFanoutBinary ::  (v ~ PTuple vl vr, PLifted (PTuple vl vr) ~ (PLifted vl, PLifted vr))
+                                  => Arrow s a v -> BinaryConstraint s vl vr -> UnaryConstraint s a
+
+compileArrow :: Arrow s a b -> PlutarchArrow s a b
+compileArrow (Arrow a) = arrow a
+compileArrow (ArrowSeq l r) =
+  plam $ \a -> papp (compileArrow r) (papp (compileArrow l) a)
+compileArrow (ArrowFanout l r) =
+  plam $ \a -> papp (papp ptuple (pdata (papp (compileArrow l) a))) (pdata (papp (compileArrow r) a))
+compileArrow (ArrowParallel l r) =
+  plam $ \alar->
+    let bip = pfromData $ pbuiltinPairFromTuple $ pdata alar
+        bl = pdata $ papp (compileArrow l) $ pfromData $ papp pfstBuiltin bip
+        br = pdata $ papp (compileArrow r) $ pfromData $ papp psndBuiltin bip
+      in papp (papp ptuple bl) br
 
 
-haskArrow :: IsoArrow s a b -> ((PLifted a) -> (PLifted b))
-haskArrow (IsoArrow a) = hArrow a
-haskArrow (IsoArrowSeq l r) = haskArrow r . haskArrow l
-haskArrow (IsoArrowFanout l r) = \a -> ((haskArrow l) a, (haskArrow r) a)
-haskArrow (IsoArrowParallel l r) = \(al,ar) -> ((haskArrow l) al, (haskArrow r) ar)
-
-haskBinaryConstraint :: IsoBinaryConstraint s a b -> ((PLifted a) -> (PLifted b) -> Bool)
-haskBinaryConstraint (IsoBinaryConstraint c) = hBinaryConstraint c
-haskBinaryConstraint (IsoBinaryConstraintAssoc l r) = \a b -> (haskBinaryConstraint l) a b && (haskBinaryConstraint r) a b
-haskBinaryConstraint (IsoBinaryConstraintArrowLeft ar c) = \a b -> (haskBinaryConstraint c) (haskArrow ar $ a) b
-haskBinaryConstraint (IsoBinaryConstraintArrowRight c ar) = \a b -> (haskBinaryConstraint c) a (haskArrow ar $ b)
-haskBinaryConstraint (IsoBinaryConstraintArrowParallel ar c) = \a b -> uncurry (haskBinaryConstraint c) ((haskArrow ar) (a, b))
-
-haskUnaryConstraint :: IsoUnaryConstraint s a -> (PLifted a -> Bool)
-haskUnaryConstraint (IsoUnaryConstraint c) = hUnaryConstraint c
-haskUnaryConstraint (IsoUnaryFromBinaryConstraint bc) = \a -> (haskBinaryConstraint bc) a a
-haskUnaryConstraint (IsoUnaryConstraintAssoc l r) = \a -> (haskUnaryConstraint l) a && (haskUnaryConstraint r) a
-haskUnaryConstraint (IsoUnaryConstraintArrow ar c) = \a -> (haskUnaryConstraint c) ((haskArrow ar) a)
+compileBinaryConstraint :: BinaryConstraint s a b -> PlutarchBinaryConstraint s a b
+compileBinaryConstraint (BinaryConstraintArrowParallel (ArrowParallel l r) c) =
+  compileBinaryConstraint $ BinaryConstraintArrowRight (BinaryConstraintArrowLeft l c) r
 
 
-plutarchArrow :: IsoArrow s a b -> PlutarchArrow s a b
-plutarchArrow (IsoArrow a) = pArrow a
-
-plutarchBinaryConstraint :: IsoBinaryConstraint s a b -> PlutarchArrow s a b
-plutarchBinaryConstraint (IsoBinaryConstraintArrowParallel (IsoArrowParallel l r) c) =
-  plutarchBinaryConstraint $ IsoBinaryConstraintArrowRight (IsoBinaryConstraintArrowLeft l c) r
-
+compileUnaryConstraint :: UnaryConstraint s a -> PlutarchUnaryConstraint s a
+compileUnaryConstraint (UnaryConstraintFanoutBinary (ArrowFanout l r) c) =
+  compileUnaryConstraint (UnaryFromBinaryConstraint (BinaryConstraintArrowRight (BinaryConstraintArrowLeft l c) r))
 
 
 

--- a/src/Apropos/Script/Iso/DSL.hs
+++ b/src/Apropos/Script/Iso/DSL.hs
@@ -1,9 +1,23 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Apropos.Script.Iso.DSL (
-  NamedArrow(..),
-  NamedUnaryConstraint(..),
-  NamedBinaryConstraint(..),
+  arrow,
+  binaryConstraint,
+  unaryConstraint,
+  (>>>),
+  (&&&),
+  (***),
+  bflip,
+  (>||),
+  (||<),
+  (>**),
+  wye,
+  (>>|),
+  (>&|),
+
+  Arrow,
+  BinaryConstraint,
+  UnaryConstraint,
   compileArrow,
   compileBinaryConstraint,
   compileUnaryConstraint,
@@ -13,22 +27,6 @@ import Plutarch.Prelude
 import Plutarch.Lift
 import Plutarch.Api.V1.Tuple
 
-class NamedArrow arrow where
-  arrowName :: arrow s a b -> String
-  mkArrow :: PlutarchArrow s a b -> arrow s a b
-  arrow :: arrow s a b -> PlutarchArrow s a b
-
-
-class NamedUnaryConstraint constraint where
-  unaryConstraintName :: constraint s a -> String
-  mkUnaryConstraint :: PlutarchUnaryConstraint s a -> constraint s a
-  unaryConstraint :: constraint s a -> PlutarchUnaryConstraint s a
-
-class NamedBinaryConstraint constraint where
-  binaryConstraintName :: constraint s a b -> String
-  mkbinaryConstraint :: PlutarchBinaryConstraint s a b -> constraint s a b
-  binaryConstraint :: constraint s a b -> PlutarchBinaryConstraint s a b
-
 type PlutarchArrow s a b = Term s (a :--> b)
 
 -- where POpaque is a truthy value e.g. perror = False, PUnit = True
@@ -37,9 +35,59 @@ type PlutarchUnaryConstraint s domain = Term s (domain :--> POpaque)
 -- where POpaque is a truthy value e.g. perror = False, PUnit = True
 type PlutarchBinaryConstraint s domainL domainR = Term s (domainL :--> domainR :--> POpaque)
 
+arrow :: PlutarchArrow s a b -> Arrow s a b
+arrow = Arrow
+
+binaryConstraint :: PlutarchBinaryConstraint s a b -> BinaryConstraint s a b
+binaryConstraint = BinaryConstraint
+
+unaryConstraint :: PlutarchUnaryConstraint s a -> UnaryConstraint s a
+unaryConstraint = UnaryConstraint
+
+(>>>) :: Arrow s a b -> Arrow s b c -> Arrow s a c
+(>>>) = ArrowSeq
+
+(&&&) :: (PIsData bl, PIsData br, b ~ PTuple bl br, PLifted (PTuple bl br) ~ (PLifted bl, PLifted br))
+      => Arrow s a bl -> Arrow s a br -> Arrow s a b
+(&&&) = ArrowFanout
+
+(***) :: (PIsData al, PIsData ar, a ~ PTuple al ar, PLifted (PTuple al ar) ~ (PLifted al, PLifted ar)
+         ,PIsData bl, PIsData br, b ~ PTuple bl br, PLifted (PTuple bl br) ~ (PLifted bl, PLifted br))
+      => Arrow s al bl -> Arrow s ar br -> Arrow s a b
+(***) = ArrowParallel
+
+bflip :: BinaryConstraint s a b -> BinaryConstraint s b a
+bflip = BinaryConstraintFlip
+
+instance Semigroup (BinaryConstraint s a b) where
+  (<>) = BinaryConstraintAssoc
+
+(>||) :: Arrow s a c -> BinaryConstraint s c b -> BinaryConstraint s a b
+(>||) = BinaryConstraintArrowLeft
+
+(||<) :: BinaryConstraint s a c -> Arrow s b c -> BinaryConstraint s a b
+(||<) = BinaryConstraintArrowRight
+
+(>**) :: (PIsData a, PIsData b, ab ~ PTuple a b, PLifted (PTuple a b) ~ (PLifted a, PLifted b)
+         ,PIsData vl, PIsData vr, v ~ PTuple vl vr, PLifted (PTuple vl vr) ~ (PLifted vl, PLifted vr))
+      => Arrow s ab v -> BinaryConstraint s vl vr -> BinaryConstraint s a b
+(>**) = BinaryConstraintArrowParallel
+
+wye :: BinaryConstraint s a a -> UnaryConstraint s a
+wye = UnaryFromBinaryConstraint
+
+instance Semigroup (UnaryConstraint s a) where
+  (<>) = UnaryConstraintAssoc
+
+(>>|) :: Arrow s a b -> UnaryConstraint s b -> UnaryConstraint s a
+(>>|) = UnaryConstraintArrow
+
+(>&|) :: (PIsData vl, PIsData vr, v ~ PTuple vl vr, PLifted (PTuple vl vr) ~ (PLifted vl, PLifted vr))
+      => Arrow s a v -> BinaryConstraint s vl vr -> UnaryConstraint s a
+(>&|) = UnaryConstraintFanoutBinary
 
 data Arrow s a b where
-  Arrow :: NamedArrow arrow => arrow s a b -> Arrow s a b
+  Arrow :: PlutarchArrow s a b -> Arrow s a b
   ArrowSeq :: Arrow s a v -> Arrow s v b -> Arrow s a b
   ArrowFanout :: (PIsData bl, PIsData br, b ~ PTuple bl br, PLifted (PTuple bl br) ~ (PLifted bl, PLifted br))
                  => Arrow s a bl -> Arrow s a br -> Arrow s a b
@@ -48,8 +96,7 @@ data Arrow s a b where
                    => Arrow s al bl -> Arrow s ar br -> Arrow s a b
 
 data BinaryConstraint s a b where
-  BinaryConstraint :: NamedBinaryConstraint constraint
-                      => constraint s a b -> BinaryConstraint s a b
+  BinaryConstraint :: PlutarchBinaryConstraint s a b -> BinaryConstraint s a b
   BinaryConstraintFlip :: BinaryConstraint s b a -> BinaryConstraint s a b
   BinaryConstraintAssoc :: BinaryConstraint s a b -> BinaryConstraint s a b -> BinaryConstraint s a b
   BinaryConstraintArrowLeft :: Arrow s a c -> BinaryConstraint s c b -> BinaryConstraint s a b
@@ -59,8 +106,7 @@ data BinaryConstraint s a b where
                                 => Arrow s ab v -> BinaryConstraint s vl vr -> BinaryConstraint s a b
 
 data UnaryConstraint s a where
-  UnaryConstraint :: NamedUnaryConstraint constraint
-                  => constraint s a -> UnaryConstraint s a
+  UnaryConstraint :: PlutarchUnaryConstraint s a -> UnaryConstraint s a
   UnaryFromBinaryConstraint :: BinaryConstraint s a a -> UnaryConstraint s a
   UnaryConstraintAssoc :: UnaryConstraint s a -> UnaryConstraint s a -> UnaryConstraint s a
   UnaryConstraintArrow :: Arrow s a b -> UnaryConstraint s b -> UnaryConstraint s a
@@ -68,7 +114,7 @@ data UnaryConstraint s a where
                               => Arrow s a v -> BinaryConstraint s vl vr -> UnaryConstraint s a
 
 compileArrow :: Arrow s a b -> PlutarchArrow s a b
-compileArrow (Arrow a) = arrow a
+compileArrow (Arrow a) = a
 compileArrow (ArrowSeq l r) =
   plam $ \a -> papp (compileArrow r) (papp (compileArrow l) a)
 compileArrow (ArrowFanout l r) = -- this reification of the tuple can be avoided by compileUnaryConstraint
@@ -84,10 +130,10 @@ opaqueSemigroup :: Term s a -> Term s b -> Term s POpaque
 opaqueSemigroup ign ore = papp (papp (plam $ \_ign _ore -> popaque $ pcon PUnit) ign) ore
 
 compileBinaryConstraint :: BinaryConstraint s a b -> PlutarchBinaryConstraint s a b
-compileBinaryConstraint (BinaryConstraint c) = binaryConstraint c
+compileBinaryConstraint (BinaryConstraint c) = c
 compileBinaryConstraint (BinaryConstraintArrowParallel (ArrowParallel l r) c) = -- this avoids the tuple reification
   compileBinaryConstraint $ BinaryConstraintArrowRight (BinaryConstraintArrowLeft l c) r
-compileBinaryConstraint (BinaryConstraintArrowParallel arr c) = --TODO rewrite arrow to ArrowParallel if possible
+compileBinaryConstraint (BinaryConstraintArrowParallel arr c) = --TODO rewrite arrow to ArrowParallel if possible via normalisation
   plam $ \a ->
     plam $ \b ->
       let tup = papp (compileArrow arr) (papp (papp ptuple (pdata a)) (pdata b))
@@ -111,7 +157,7 @@ compileBinaryConstraint (BinaryConstraintArrowRight c arr) =
       papp (papp (compileBinaryConstraint c) a) (papp (compileArrow arr) b)
 
 compileUnaryConstraint :: UnaryConstraint s a -> PlutarchUnaryConstraint s a
-compileUnaryConstraint (UnaryConstraint c) = unaryConstraint c
+compileUnaryConstraint (UnaryConstraint c) = c
 compileUnaryConstraint (UnaryConstraintFanoutBinary (ArrowFanout l r) c) = -- this avoids the tuple reification
   compileUnaryConstraint (UnaryFromBinaryConstraint (BinaryConstraintArrowRight (BinaryConstraintArrowLeft l c) r))
 compileUnaryConstraint (UnaryFromBinaryConstraint c) =
@@ -120,7 +166,7 @@ compileUnaryConstraint (UnaryConstraintAssoc l r) =
   plam $ \a -> opaqueSemigroup (papp (compileUnaryConstraint l) a) (papp (compileUnaryConstraint r) a)
 compileUnaryConstraint (UnaryConstraintArrow arr c) =
   plam $ \a -> papp (compileUnaryConstraint c) (papp (compileArrow arr) a)
-compileUnaryConstraint (UnaryConstraintFanoutBinary arr c) = --TODO rewrite arr to ArrowFanout if possible
+compileUnaryConstraint (UnaryConstraintFanoutBinary arr c) = --TODO rewrite arr to ArrowFanout if possible via normalisation
   plam $ \a ->
     let tup = papp (compileArrow arr) a
         bip = pfromData $ pbuiltinPairFromTuple $ pdata tup

--- a/src/Apropos/Script/Iso/DSL.hs
+++ b/src/Apropos/Script/Iso/DSL.hs
@@ -65,6 +65,8 @@ data IsoUnaryConstraint s a where
   IsoUnaryFromBinaryConstraint :: IsoBinaryConstraint s a a -> IsoUnaryConstraint s a
   IsoUnaryConstraintAssoc :: IsoUnaryConstraint s a -> IsoUnaryConstraint s a -> IsoUnaryConstraint s a
   IsoUnaryConstraintArrow :: IsoArrow s a b -> IsoUnaryConstraint s b -> IsoUnaryConstraint s a
+  IsoUnaryConstraintFanoutBinary ::  (v ~ PTuple vl vr, PLifted (PTuple vl vr) ~ (PLifted vl, PLifted vr))
+                                  => IsoArrow s a v -> IsoBinaryConstraint s vl vr -> IsoUnaryConstraint s a
 
 
 haskArrow :: IsoArrow s a b -> ((PLifted a) -> (PLifted b))

--- a/src/Apropos/Script/Iso/DSL.hs
+++ b/src/Apropos/Script/Iso/DSL.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Apropos.Script.Iso.DSL (
+  NamedArrow(..),
+  UnaryConstraint(..),
+  BinaryConstraint(..),
+  haskUnaryConstraint,
+) where
+import Plutarch
+import Plutarch.Lift
+import Plutarch.Api.V1.Tuple
+
+class NamedArrow arrow where
+  arrow :: (a -> b) -> arrow a b
+  unArrow :: arrow a b -> (a -> b)
+  arrowName :: arrow a b -> String
+
+class UnaryConstraint c where
+  unaryConstraint :: (a -> Bool) -> c a
+  unUnaryConstraint :: c a -> (a -> Bool)
+  unaryConstraintName :: c a -> String
+
+class BinaryConstraint c where
+  binaryConstraint :: (a -> b -> Bool) -> c a b
+  unBinaryConstraint :: c a b -> (a -> b -> Bool)
+  binaryConstraintName :: c a b -> String
+
+
+type PlutarchArrow s antecedent consequent = Term s (antecedent :--> consequent)
+
+-- where POpaque is a truthy value e.g. perror = False, PUnit = True
+type PlutarchUnaryConstraint s domain = Term s (domain :--> POpaque)
+
+-- where POpaque is a truthy value e.g. perror = False, PUnit = True
+type PlutarchBinaryConstraint s domainL domainR = Term s (domainL :--> domainR :--> POpaque)
+
+
+data IsoArrow s a b where
+  IsoArrow :: (PLift a, PLift b, NamedArrow arrow)
+           => arrow (PLifted a) (PLifted b) -> PlutarchArrow s a b -> IsoArrow s a b
+  IsoArrowSeq :: IsoArrow s a v -> IsoArrow s v b -> IsoArrow s a b
+  IsoArrowFanout :: (b ~ PTuple bl br, PLifted (PTuple bl br) ~ (PLifted bl, PLifted br))
+                 => IsoArrow s a bl -> IsoArrow s a br -> IsoArrow s a b
+  IsoArrowParallel :: (a ~ PTuple al ar, PLifted (PTuple al ar) ~ (PLifted al, PLifted ar)
+                      ,b ~ PTuple bl br, PLifted (PTuple bl br) ~ (PLifted bl, PLifted br))
+                   => IsoArrow s al bl -> IsoArrow s ar br -> IsoArrow s a b
+
+data IsoBinaryConstraint s a b where
+  IsoBinaryConstraint :: (PLift a, PLift b, BinaryConstraint c , Show (c (PLifted a) (PLifted b)))
+                      => c (PLifted a) (PLifted b) -> PlutarchBinaryConstraint s a b -> IsoBinaryConstraint s a b
+  IsoBinaryConstraintAssoc :: IsoBinaryConstraint s a b -> IsoBinaryConstraint s a b -> IsoBinaryConstraint s a b
+  IsoBinaryConstraintArrowLeft :: IsoArrow s a c -> IsoBinaryConstraint s c b -> IsoBinaryConstraint s a b
+  IsoBinaryConstraintArrowRight :: IsoBinaryConstraint s a c -> IsoArrow s b c -> IsoBinaryConstraint s a b
+  IsoBinaryConstraintArrowParallel :: (ab ~ PTuple a b, PLifted (PTuple a b) ~ (PLifted a, PLifted b)
+                                      ,v ~ PTuple vl vr, PLifted (PTuple vl vr) ~ (PLifted vl, PLifted vr))
+                                  => IsoArrow s ab v -> IsoBinaryConstraint s vl vr -> IsoBinaryConstraint s a b
+
+
+data IsoUnaryConstraint s a where
+  IsoUnaryConstraint :: (PLift a, UnaryConstraint c, Show (c (PLifted a)))
+                     => c (PLifted a) -> PlutarchUnaryConstraint s a -> IsoUnaryConstraint s a
+  IsoUnaryFromBinaryConstraint :: IsoBinaryConstraint s a a -> IsoUnaryConstraint s a
+  IsoUnaryConstraintAssoc :: IsoUnaryConstraint s a -> IsoUnaryConstraint s a -> IsoUnaryConstraint s a
+  IsoUnaryConstraintArrow :: IsoArrow s a b -> IsoUnaryConstraint s b -> IsoUnaryConstraint s a
+
+
+haskArrow :: IsoArrow s a b -> ((PLifted a) -> (PLifted b))
+haskArrow (IsoArrow a _) = unArrow a
+haskArrow (IsoArrowSeq l r) = haskArrow r . haskArrow l
+haskArrow (IsoArrowFanout l r) = \a -> ((haskArrow l) a, (haskArrow r) a)
+haskArrow (IsoArrowParallel l r) = \(al,ar) -> ((haskArrow l) al, (haskArrow r) ar)
+
+haskBinaryConstraint :: IsoBinaryConstraint s a b -> ((PLifted a) -> (PLifted b) -> Bool)
+haskBinaryConstraint (IsoBinaryConstraint c _) = unBinaryConstraint c
+haskBinaryConstraint (IsoBinaryConstraintAssoc l r) = \a b -> (haskBinaryConstraint l) a b && (haskBinaryConstraint r) a b
+haskBinaryConstraint (IsoBinaryConstraintArrowLeft ar c) = \a b -> (haskBinaryConstraint c) (haskArrow ar $ a) b
+haskBinaryConstraint (IsoBinaryConstraintArrowRight c ar) = \a b -> (haskBinaryConstraint c) a (haskArrow ar $ b)
+haskBinaryConstraint (IsoBinaryConstraintArrowParallel ar c) = \a b -> uncurry (haskBinaryConstraint c) ((haskArrow ar) (a, b))
+
+haskUnaryConstraint :: IsoUnaryConstraint s a -> (PLifted a -> Bool)
+haskUnaryConstraint (IsoUnaryConstraint c _) = unUnaryConstraint c
+haskUnaryConstraint (IsoUnaryFromBinaryConstraint bc) = \a -> (haskBinaryConstraint bc) a a
+haskUnaryConstraint (IsoUnaryConstraintAssoc l r) = \a -> (haskUnaryConstraint l) a && (haskUnaryConstraint r) a
+haskUnaryConstraint (IsoUnaryConstraintArrow ar c) = \a -> (haskUnaryConstraint c) ((haskArrow ar) a)
+
+
+

--- a/src/Plutarch/ArrowDSL.hs
+++ b/src/Plutarch/ArrowDSL.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RankNTypes #-}
 
-module Apropos.Script.Iso.DSL (
+module Plutarch.ArrowDSL (
   arrow,
   binaryConstraint,
   unaryConstraint,

--- a/src/Plutarch/ArrowDSL.hs
+++ b/src/Plutarch/ArrowDSL.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE RankNTypes #-}
-
 module Plutarch.ArrowDSL (
   arrow,
   binaryConstraint,
@@ -112,6 +111,20 @@ data UnaryConstraint s a where
   UnaryConstraintArrow :: Arrow s a b -> UnaryConstraint s b -> UnaryConstraint s a
   UnaryConstraintFanoutBinary :: (PIsData vl, PIsData vr, v ~ PTuple vl vr, PLifted (PTuple vl vr) ~ (PLifted vl, PLifted vr))
                               => Arrow s a v -> BinaryConstraint s vl vr -> UnaryConstraint s a
+
+--normaliseArrow :: Arrow s a b -> Arrow s a b
+--normaliseArrow a@(Arrow _) = a
+--normaliseArrow a@(ArrowSeq (ArrowFanout _ _) (Arrow _)) = a
+--normaliseArrow (ArrowSeq a@(Arrow _) b) = ArrowSeq a (normaliseArrow b)
+--normaliseArrow (ArrowSeq a@(ArrowFanout _ _) b@(ArrowFanout _ _)) = ArrowSeq a (normaliseArrow b)
+--normaliseArrow (ArrowSeq (ArrowSeq l v) r) = normaliseArrow $ ArrowSeq l (ArrowSeq v r)
+--normaliseArrow (ArrowSeq (ArrowFanout l' r') (ArrowParallel l r)) =
+--  normaliseArrow $ ArrowFanout (ArrowSeq l' l) (ArrowSeq r' r)
+--normaliseArrow (ArrowSeq (ArrowParallel l' r') (ArrowParallel l r)) =
+--  normaliseArrow $ ArrowParallel (ArrowSeq l' l) (ArrowSeq r' r)
+--normaliseArrow (ArrowFanout a b) = ArrowFanout (normaliseArrow a) (normaliseArrow b)
+--normaliseArrow (ArrowParallel a b) = ArrowParallel (normaliseArrow a) (normaliseArrow b)
+
 
 compileArrow :: Arrow s a b -> PlutarchArrow s a b
 compileArrow (Arrow a) = a

--- a/src/Plutarch/ShowProxyLiftedType.hs
+++ b/src/Plutarch/ShowProxyLiftedType.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+module Plutarch.ShowProxyLiftedType (
+  showProxyLiftedType,
+  ) where
+import Plutarch.Lift
+import Data.Proxy
+import Type.Reflection
+
+-- this works (it prints the type of (PLifted a) but only if you can explicitly tell
+-- it what that type is... so not all that useful
+showProxyLiftedType :: forall a . Typeable (PLifted a) => Proxy (PLifted a) -> String
+showProxyLiftedType a = drop 8 $ show (typeOf a)
+


### PR DESCRIPTION
Reifying the arrows and constraints in a DSL AST has some benefits.
- we can pretty print the AST with graphviz
- we can better compose the components of the AST - eliminate introduction of unnecessary terms